### PR TITLE
feat: Add K8s jobs list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Python-based CLI toolkit for automating daily DevOps operations.
 
 ## Features
 
-- **Kubernetes Management**: Manage pods, services, and certificates from the command line
+- **Kubernetes Management**: Manage pods, services, jobs, and certificates from the command line
 - **File Validation**: Validate YAML and JSON files for syntax errors with detailed error reporting
 - **Human-readable Output**: Formatted tables with Rich for clear visualization
 - **Metrics Support**: View CPU and memory usage for pods (requires Metrics Server)
@@ -86,6 +86,22 @@ devopstoolbox k8s services list -n kube-system
 devopstoolbox k8s services list -A
 ```
 
+### Jobs Management
+
+```bash
+# List all jobs in default namespace
+devopstoolbox k8s jobs list
+
+# List all jobs in a specific namespace
+devopstoolbox k8s jobs list -n batch
+
+# List all jobs across all namespaces
+devopstoolbox k8s jobs list -A
+
+# List only failed jobs
+devopstoolbox k8s jobs failed -A
+```
+
 ### Certificates Management
 
 ```bash
@@ -124,6 +140,8 @@ devopstoolbox validate json -d ./configs
 | `devopstoolbox k8s pods metrics`           | Show CPU and memory usage per container    |
 | `devopstoolbox k8s pods unhealthy`         | List pods not in Running/Succeeded state   |
 | `devopstoolbox k8s services list`          | List services with type and traffic policy |
+| `devopstoolbox k8s jobs list`              | List jobs with status and age              |
+| `devopstoolbox k8s jobs failed`            | List only failed jobs with error messages  |
 | `devopstoolbox k8s certificates list`      | List cert-manager certificates             |
 | `devopstoolbox k8s certificates not-ready` | List certificates not in Ready state       |
 | `devopstoolbox validate yaml`              | Validate YAML files for syntax errors      |

--- a/src/devopstoolbox/k8s/jobs.py
+++ b/src/devopstoolbox/k8s/jobs.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 import typer
 from kubernetes import client
 from rich.console import Console
@@ -7,30 +9,34 @@ from devopstoolbox.k8s import utils
 
 app = typer.Typer(no_args_is_help=True)
 console = Console()
-config = utils.get_kube_config()
-# custom_api = CustomObjectsApi()
 
 
 @app.command()
-def list(namespace: str = "default", all_namespaces: bool = False):
-    """List pods"""
-    scope = "all_namespaces" if all_namespaces else namespace
-    console.print(f"[bold blue]Listing pods in {scope}...[/bold blue]")
+def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
+    """List Jobs"""
+    utils.load_kube_config()
+    namespace = namespace or utils.get_current_namespace()
+    scope = "all namespaces" if all_namespaces else f"namespace {namespace}"
+    console.print(f"[bold blue]Listing jobs in {scope}...[/bold blue]")
 
     try:
-        v1 = client.BatchV1Api
-        jobs = v1.list_job_for_all_namespaces(watch=False) if all_namespaces else v1.list_namespaced_job(scope, watch=False)
+        v1 = client.BatchV1Api()
+        jobs = v1.list_job_for_all_namespaces(watch=False) if all_namespaces else v1.list_namespaced_job(namespace=namespace, watch=False)
 
         table = Table(title=f"Jobs in {scope}")
         table.add_column("Namespace", style="cyan", justify="center")
-        table.add_column("Pod Name", style="green", justify="center")
-        table.add_column("Status", style="green", justify="center")
-        table.add_column("Restart Count", justify="center")
+        table.add_column("Job Name", style="green", justify="center")
+        table.add_column("Suspended?", style="green", justify="center")
+        # table.add_column("Restart Count", justify="center")
 
         for job in jobs.items:
-            statuses = job.status.container_statuses or []
-            restart_count = sum((status.restart_count or 0) for status in statuses)
-            table.add_row(job.metadata.namespace or "-", job.metadata.name, job.status.phase, str(restart_count))
+            print(job.metadata.name)
+            table.add_row(job.metadata.namespace or "-", job.metadata.name, f"{job.spec.suspend}")
+
+        # for job in jobs.items:
+        #     statuses = job.status.container_statuses or []
+        #     restart_count = sum((status.restart_count or 0) for status in statuses)
+        #     table.add_row(job.metadata.namespace or "-", job.metadata.name, job.status.phase, str(restart_count))
 
         console.print(table)
     except Exception as err:

--- a/src/devopstoolbox/k8s/jobs.py
+++ b/src/devopstoolbox/k8s/jobs.py
@@ -1,0 +1,37 @@
+import typer
+from kubernetes import client
+from rich.console import Console
+from rich.table import Table
+
+from devopstoolbox.k8s import utils
+
+app = typer.Typer(no_args_is_help=True)
+console = Console()
+config = utils.get_kube_config()
+# custom_api = CustomObjectsApi()
+
+
+@app.command()
+def list(namespace: str = "default", all_namespaces: bool = False):
+    """List pods"""
+    scope = "all_namespaces" if all_namespaces else namespace
+    console.print(f"[bold blue]Listing pods in {scope}...[/bold blue]")
+
+    try:
+        v1 = client.BatchV1Api
+        jobs = v1.list_job_for_all_namespaces(watch=False) if all_namespaces else v1.list_namespaced_job(scope, watch=False)
+
+        table = Table(title=f"Jobs in {scope}")
+        table.add_column("Namespace", style="cyan", justify="center")
+        table.add_column("Pod Name", style="green", justify="center")
+        table.add_column("Status", style="green", justify="center")
+        table.add_column("Restart Count", justify="center")
+
+        for job in jobs.items:
+            statuses = job.status.container_statuses or []
+            restart_count = sum((status.restart_count or 0) for status in statuses)
+            table.add_row(job.metadata.namespace or "-", job.metadata.name, job.status.phase, str(restart_count))
+
+        console.print(table)
+    except Exception as err:
+        console.print(f"[bold red]Error accessing Kubernetes:[/bold red] \n\n{err}")

--- a/src/devopstoolbox/k8s/jobs.py
+++ b/src/devopstoolbox/k8s/jobs.py
@@ -28,6 +28,7 @@ def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, al
         table.add_column("Job Name", style="green", justify="center")
         table.add_column("Suspended?", style="green", justify="center")
         table.add_column("Status", style="green", justify="center")
+        table.add_column("Age", style="green", justify="center")
 
         for job in jobs.items:
             job_status = "Running"
@@ -40,12 +41,39 @@ def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, al
                         job_status = "[green]Complete[/green]"
 
             suspended = "Yes" if job.spec.suspend else "No"
-            table.add_row(
-                job.metadata.namespace or "-",
-                job.metadata.name,
-                suspended,
-                job_status
-            )
+            table.add_row(job.metadata.namespace or "-", job.metadata.name, suspended, job_status, utils.calculate_age(job.status.start_time))
+        console.print(table)
+    except Exception as err:
+        console.print(f"[bold red]Error accessing Kubernetes:[/bold red] \n\n{err}")
+
+
+@app.command()
+def failed(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
+    """List only failed Jobs"""
+    utils.load_kube_config()
+    namespace = namespace or utils.get_current_namespace()
+    scope = "all namespaces" if all_namespaces else f"namespace {namespace}"
+    console.print(f"[bold blue]Listing jobs in {scope}...[/bold blue]")
+
+    try:
+        v1 = client.BatchV1Api()
+        jobs = v1.list_job_for_all_namespaces(watch=False) if all_namespaces else v1.list_namespaced_job(namespace=namespace, watch=False)
+
+        table = Table(title=f"Jobs in {scope}")
+        table.add_column("Namespace", style="cyan", justify="center")
+        table.add_column("Job Name", style="green", justify="center")
+        table.add_column("Status", style="green", justify="center")
+        table.add_column("Message", style="green", justify="center")
+        table.add_column("Age", style="green", justify="center")
+
+        for job in jobs.items:
+            job_status = "Running"
+            if job.status.conditions:
+                for condition in job.status.conditions:
+                    if condition.type == "Failed" and condition.status == "True":
+                        job_status = "[red]Failed[/red]"
+                        table.add_row(job.metadata.namespace or "-", job.metadata.name, job_status, condition.message, utils.calculate_age(job.status.start_time))
+                        break
         console.print(table)
     except Exception as err:
         console.print(f"[bold red]Error accessing Kubernetes:[/bold red] \n\n{err}")

--- a/src/devopstoolbox/k8s/jobs.py
+++ b/src/devopstoolbox/k8s/jobs.py
@@ -27,17 +27,17 @@ def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, al
         table.add_column("Namespace", style="cyan", justify="center")
         table.add_column("Job Name", style="green", justify="center")
         table.add_column("Suspended?", style="green", justify="center")
-        # table.add_column("Restart Count", justify="center")
+        table.add_column("Status", style="green", justify="center")
 
         for job in jobs.items:
+            job_status = "-"
             print(job.metadata.name)
-            table.add_row(job.metadata.namespace or "-", job.metadata.name, f"{job.spec.suspend}")
-
-        # for job in jobs.items:
-        #     statuses = job.status.container_statuses or []
-        #     restart_count = sum((status.restart_count or 0) for status in statuses)
-        #     table.add_row(job.metadata.namespace or "-", job.metadata.name, job.status.phase, str(restart_count))
-
+            for condition in job.status.conditions:
+                if condition.type == "Failed":
+                    job_status = "Failed"
+                else:
+                    job_status = "Success"
+            table.add_row(job.metadata.namespace or "-", job.metadata.name, f"{job.spec.suspend}", f"{job_status}")
         console.print(table)
     except Exception as err:
         console.print(f"[bold red]Error accessing Kubernetes:[/bold red] \n\n{err}")

--- a/src/devopstoolbox/k8s/jobs.py
+++ b/src/devopstoolbox/k8s/jobs.py
@@ -30,14 +30,22 @@ def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, al
         table.add_column("Status", style="green", justify="center")
 
         for job in jobs.items:
-            job_status = "-"
-            print(job.metadata.name)
-            for condition in job.status.conditions:
-                if condition.type == "Failed":
-                    job_status = "Failed"
-                else:
-                    job_status = "Success"
-            table.add_row(job.metadata.namespace or "-", job.metadata.name, f"{job.spec.suspend}", f"{job_status}")
+            job_status = "Running"
+            if job.status.conditions:
+                for condition in job.status.conditions:
+                    if condition.type == "Failed" and condition.status == "True":
+                        job_status = "[red]Failed[/red]"
+                        break
+                    elif condition.type == "Complete" and condition.status == "True":
+                        job_status = "[green]Complete[/green]"
+
+            suspended = "Yes" if job.spec.suspend else "No"
+            table.add_row(
+                job.metadata.namespace or "-",
+                job.metadata.name,
+                suspended,
+                job_status
+            )
         console.print(table)
     except Exception as err:
         console.print(f"[bold red]Error accessing Kubernetes:[/bold red] \n\n{err}")

--- a/src/devopstoolbox/k8s/pods.py
+++ b/src/devopstoolbox/k8s/pods.py
@@ -27,13 +27,14 @@ def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, al
         table = Table(title=f"Pods in {scope}")
         table.add_column("Namespace", style="cyan", justify="center")
         table.add_column("Pod Name", style="green", justify="center")
-        table.add_column("Status", style="green", justify="center")
         table.add_column("Restart Count", justify="center")
+        table.add_column("Age", justify="center")
+        table.add_column("Status", style="green", justify="center")
 
         for pod in pods.items:
             statuses = pod.status.container_statuses or []
             restart_count = sum((status.restart_count or 0) for status in statuses)
-            table.add_row(pod.metadata.namespace or "-", pod.metadata.name, pod.status.phase, str(restart_count))
+            table.add_row(pod.metadata.namespace or "-", pod.metadata.name, str(restart_count), utils.calculate_age(pod.status.start_time), pod.status.phase)
 
         console.print(table)
     except Exception as err:
@@ -133,14 +134,15 @@ def unhealthy(namespace: Annotated[str, typer.Option("--namespace", "-n")] = Non
         table = Table(title=f"Pods in {scope}")
         table.add_column("Namespace", style="cyan", justify="center")
         table.add_column("Pod Name", style="green", justify="center")
-        table.add_column("Status", style="green", justify="center")
         table.add_column("Restart Count", justify="center")
+        table.add_column("Age", justify="center")
+        table.add_column("Status", style="green", justify="center")
 
         for pod in pods.items:
             statuses = pod.status.container_statuses or []
             restart_count = sum((status.restart_count or 0) for status in statuses)
             if pod.status.phase not in ("Running", "Succeeded"):
-                table.add_row(pod.metadata.namespace or "-", pod.metadata.name, pod.status.phase, str(restart_count))
+                table.add_row(pod.metadata.namespace or "-", pod.metadata.name, str(restart_count), utils.calculate_age(pod.status.start_time), pod.status.phase)
 
         console.print(table)
     except Exception as err:

--- a/src/devopstoolbox/k8s/utils.py
+++ b/src/devopstoolbox/k8s/utils.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime, timezone
 
 import urllib3
 from kubernetes import config
@@ -81,6 +82,7 @@ def parse_memory(mem_str: str, return_number: bool = False):
 
 
 def calculate_cpu_percentage(usage, limit):
+    """Calculate CPU usage percentage from usage and limit values."""
     if usage is None or limit is None or not (usage[:-1].isdigit() or usage.isdigit()) or not (limit[:-1].isdigit() or limit.isdigit()):
         return "-"
     else:
@@ -89,8 +91,25 @@ def calculate_cpu_percentage(usage, limit):
 
 
 def calculate_memory_percentage(usage, limit):
+    """Calculate Memory usage percentage from usage and limit values."""
     if usage is None or limit is None or not usage[:-2].isdigit() or not limit[:-2].isdigit():
         return "-"
     else:
         result = parse_memory(usage, return_number=True) / parse_memory(limit, return_number=True) * 100
         return f"{result:.2f}%"
+
+
+def calculate_age(start_time):
+    """Format a timedelta object into a human-readable string."""
+    td = datetime.now(timezone.utc) - start_time
+    days = td.days
+    hours, remainder = divmod(td.seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if days > 0:
+        return f"{days}d"
+    elif days == 0 and hours > 0:
+        return f"{hours}h{minutes}m"
+    elif hours == 0 and minutes >= 0:
+        return f"{minutes}m{seconds}s"
+    else:
+        return f"{seconds}s"

--- a/src/devopstoolbox/main.py
+++ b/src/devopstoolbox/main.py
@@ -2,7 +2,7 @@ import typer
 from rich import print
 
 from devopstoolbox import generate, validate
-from devopstoolbox.k8s import certificates, pods, services
+from devopstoolbox.k8s import certificates, jobs, pods, services
 
 __version__ = "DevOpsToolbox v0.1.0"
 

--- a/src/devopstoolbox/main.py
+++ b/src/devopstoolbox/main.py
@@ -1,7 +1,7 @@
 import typer
 from rich import print
 
-from devopstoolbox.k8s import certificates, pods, services
+from devopstoolbox.k8s import certificates, jobs, pods, services
 
 __version__ = "DevOpsToolbox v0.1.0"
 
@@ -10,6 +10,7 @@ k8s_app = typer.Typer(no_args_is_help=True)
 
 app.add_typer(k8s_app, name="k8s")
 k8s_app.add_typer(pods.app, name="pods", help="Manager Pods")
+k8s_app.add_typer(jobs.app, name="jobs", help="Manager Jobs")
 k8s_app.add_typer(services.app, name="services", help="Manager Services")
 k8s_app.add_typer(certificates.app, name="certificates", help="Manager Certificates")
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,535 @@
+"""Tests for devopstoolbox.k8s.jobs module."""
+
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from devopstoolbox.k8s import jobs
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def mock_kube_config():
+    """Mock kubeconfig loading for all tests."""
+    with patch("devopstoolbox.k8s.utils.load_kube_config"):
+        with patch("devopstoolbox.k8s.jobs.utils.calculate_age", return_value="1h30m"):
+            yield
+
+
+@pytest.fixture
+def mock_completed_job():
+    """Create a mock completed job object."""
+    job = Mock()
+    job.metadata.namespace = "default"
+    job.metadata.name = "completed-job"
+    job.spec.suspend = False
+    job.status.start_time = datetime.now(timezone.utc)
+
+    condition = Mock()
+    condition.type = "Complete"
+    condition.status = "True"
+    job.status.conditions = [condition]
+
+    return job
+
+
+@pytest.fixture
+def mock_failed_job():
+    """Create a mock failed job object."""
+    job = Mock()
+    job.metadata.namespace = "default"
+    job.metadata.name = "failed-job"
+    job.spec.suspend = False
+    job.status.start_time = datetime.now(timezone.utc)
+
+    condition = Mock()
+    condition.type = "Failed"
+    condition.status = "True"
+    condition.message = "BackoffLimitExceeded"
+    job.status.conditions = [condition]
+
+    return job
+
+
+@pytest.fixture
+def mock_running_job():
+    """Create a mock running job object (no conditions yet)."""
+    job = Mock()
+    job.metadata.namespace = "default"
+    job.metadata.name = "running-job"
+    job.spec.suspend = False
+    job.status.conditions = None
+    job.status.start_time = datetime.now(timezone.utc)
+
+    return job
+
+
+@pytest.fixture
+def mock_suspended_job():
+    """Create a mock suspended job object."""
+    job = Mock()
+    job.metadata.namespace = "default"
+    job.metadata.name = "suspended-job"
+    job.spec.suspend = True
+    job.status.conditions = None
+    job.status.start_time = datetime.now(timezone.utc)
+
+    return job
+
+
+class TestJobsListCommand:
+    """Tests for jobs list command."""
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_default_namespace(self, mock_api, mock_completed_job):
+        """Test listing jobs in default namespace."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_completed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-n", "default"])
+
+        assert result.exit_code == 0
+        mock_v1.list_namespaced_job.assert_called_once_with(namespace="default", watch=False)
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_specific_namespace_long(self, mock_api, mock_completed_job):
+        """Test listing jobs in a specific namespace with long flag."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_completed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "--namespace", "kube-system"])
+
+        assert result.exit_code == 0
+        mock_v1.list_namespaced_job.assert_called_once_with(namespace="kube-system", watch=False)
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_specific_namespace_short(self, mock_api, mock_completed_job):
+        """Test listing jobs in a specific namespace with short flag."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_completed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-n", "kube-system"])
+
+        assert result.exit_code == 0
+        mock_v1.list_namespaced_job.assert_called_once_with(namespace="kube-system", watch=False)
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_all_namespaces_long(self, mock_api, mock_completed_job):
+        """Test listing jobs across all namespaces with long flag."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_completed_job]
+        mock_v1.list_job_for_all_namespaces.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "--all-namespaces"])
+
+        assert result.exit_code == 0
+        mock_v1.list_job_for_all_namespaces.assert_called_once_with(watch=False)
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_all_namespaces_short(self, mock_api, mock_completed_job):
+        """Test listing jobs across all namespaces with short flag."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_completed_job]
+        mock_v1.list_job_for_all_namespaces.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-A"])
+
+        assert result.exit_code == 0
+        mock_v1.list_job_for_all_namespaces.assert_called_once_with(watch=False)
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_displays_completed_status(self, mock_api, mock_completed_job):
+        """Test that completed jobs show Complete status."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_completed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "completed-job" in result.output
+        assert "Complete" in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_displays_failed_status(self, mock_api, mock_failed_job):
+        """Test that failed jobs show Failed status."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_failed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "failed-job" in result.output
+        assert "Failed" in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_displays_running_status(self, mock_api, mock_running_job):
+        """Test that running jobs (no conditions) show Running status."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_running_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "running-job" in result.output
+        assert "Running" in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_displays_suspended_yes(self, mock_api, mock_suspended_job):
+        """Test that suspended jobs show Yes in suspended column."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_suspended_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "suspended-job" in result.output
+        assert "Yes" in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_displays_suspended_no(self, mock_api, mock_completed_job):
+        """Test that non-suspended jobs show No in suspended column."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_completed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "No" in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_handles_no_conditions(self, mock_api):
+        """Test handling jobs with no conditions (None)."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        job = Mock()
+        job.metadata.namespace = "default"
+        job.metadata.name = "pending-job"
+        job.spec.suspend = False
+        job.status.conditions = None
+        job.status.start_time = datetime.now(timezone.utc)
+
+        mock_jobs = Mock()
+        mock_jobs.items = [job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "pending-job" in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_handles_empty_conditions(self, mock_api):
+        """Test handling jobs with empty conditions list."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        job = Mock()
+        job.metadata.namespace = "default"
+        job.metadata.name = "new-job"
+        job.spec.suspend = False
+        job.status.conditions = []
+        job.status.start_time = datetime.now(timezone.utc)
+
+        mock_jobs = Mock()
+        mock_jobs.items = [job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "new-job" in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_handles_api_error(self, mock_api):
+        """Test handling Kubernetes API errors."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+        mock_v1.list_namespaced_job.side_effect = Exception("API Error")
+
+        result = runner.invoke(jobs.app, ["list", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "Error" in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_prioritizes_failed_over_complete(self, mock_api):
+        """Test that Failed status takes priority when both conditions exist."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        job = Mock()
+        job.metadata.namespace = "default"
+        job.metadata.name = "mixed-job"
+        job.spec.suspend = False
+        job.status.start_time = datetime.now(timezone.utc)
+
+        complete_condition = Mock()
+        complete_condition.type = "Complete"
+        complete_condition.status = "True"
+
+        failed_condition = Mock()
+        failed_condition.type = "Failed"
+        failed_condition.status = "True"
+
+        job.status.conditions = [complete_condition, failed_condition]
+
+        mock_jobs = Mock()
+        mock_jobs.items = [job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "Failed" in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_list_jobs_multiple_jobs(self, mock_api, mock_completed_job, mock_failed_job, mock_running_job):
+        """Test listing multiple jobs with different statuses."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_completed_job, mock_failed_job, mock_running_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["list", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "completed-job" in result.output
+        assert "failed-job" in result.output
+        assert "running-job" in result.output
+
+
+class TestJobsFailedCommand:
+    """Tests for jobs failed command."""
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_failed_jobs_default_namespace(self, mock_api, mock_failed_job):
+        """Test listing failed jobs in default namespace."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_failed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["failed", "-n", "default"])
+
+        assert result.exit_code == 0
+        mock_v1.list_namespaced_job.assert_called_once_with(namespace="default", watch=False)
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_failed_jobs_specific_namespace_long(self, mock_api, mock_failed_job):
+        """Test listing failed jobs in a specific namespace with long flag."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_failed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["failed", "--namespace", "kube-system"])
+
+        assert result.exit_code == 0
+        mock_v1.list_namespaced_job.assert_called_once_with(namespace="kube-system", watch=False)
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_failed_jobs_specific_namespace_short(self, mock_api, mock_failed_job):
+        """Test listing failed jobs in a specific namespace with short flag."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_failed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["failed", "-n", "kube-system"])
+
+        assert result.exit_code == 0
+        mock_v1.list_namespaced_job.assert_called_once_with(namespace="kube-system", watch=False)
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_failed_jobs_all_namespaces_long(self, mock_api, mock_failed_job):
+        """Test listing failed jobs across all namespaces with long flag."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_failed_job]
+        mock_v1.list_job_for_all_namespaces.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["failed", "--all-namespaces"])
+
+        assert result.exit_code == 0
+        mock_v1.list_job_for_all_namespaces.assert_called_once_with(watch=False)
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_failed_jobs_all_namespaces_short(self, mock_api, mock_failed_job):
+        """Test listing failed jobs across all namespaces with short flag."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_failed_job]
+        mock_v1.list_job_for_all_namespaces.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["failed", "-A"])
+
+        assert result.exit_code == 0
+        mock_v1.list_job_for_all_namespaces.assert_called_once_with(watch=False)
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_failed_jobs_displays_failed_job(self, mock_api, mock_failed_job):
+        """Test that failed jobs are displayed."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_failed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["failed", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "failed-job" in result.output
+        assert "Failed" in result.output
+        assert "BackoffLimitExceeded" in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_failed_jobs_filters_completed_jobs(self, mock_api, mock_completed_job, mock_failed_job):
+        """Test that completed jobs are filtered out."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_completed_job, mock_failed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["failed", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "failed-job" in result.output
+        assert "completed-job" not in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_failed_jobs_filters_running_jobs(self, mock_api, mock_running_job, mock_failed_job):
+        """Test that running jobs are filtered out."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_running_job, mock_failed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["failed", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "failed-job" in result.output
+        assert "running-job" not in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_failed_jobs_handles_no_failed_jobs(self, mock_api, mock_completed_job):
+        """Test handling when no failed jobs exist."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        mock_jobs = Mock()
+        mock_jobs.items = [mock_completed_job]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["failed", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "completed-job" not in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_failed_jobs_handles_api_error(self, mock_api):
+        """Test handling Kubernetes API errors."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+        mock_v1.list_namespaced_job.side_effect = Exception("API Error")
+
+        result = runner.invoke(jobs.app, ["failed", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "Error" in result.output
+
+    @patch("devopstoolbox.k8s.jobs.client.BatchV1Api")
+    def test_failed_jobs_multiple_failed(self, mock_api):
+        """Test listing multiple failed jobs."""
+        mock_v1 = Mock()
+        mock_api.return_value = mock_v1
+
+        job1 = Mock()
+        job1.metadata.namespace = "default"
+        job1.metadata.name = "failed-job-1"
+        job1.spec.suspend = False
+        job1.status.start_time = datetime.now(timezone.utc)
+        condition1 = Mock()
+        condition1.type = "Failed"
+        condition1.status = "True"
+        condition1.message = "Error message 1"
+        job1.status.conditions = [condition1]
+
+        job2 = Mock()
+        job2.metadata.namespace = "default"
+        job2.metadata.name = "failed-job-2"
+        job2.spec.suspend = False
+        job2.status.start_time = datetime.now(timezone.utc)
+        condition2 = Mock()
+        condition2.type = "Failed"
+        condition2.status = "True"
+        condition2.message = "Error message 2"
+        job2.status.conditions = [condition2]
+
+        mock_jobs = Mock()
+        mock_jobs.items = [job1, job2]
+        mock_v1.list_namespaced_job.return_value = mock_jobs
+
+        result = runner.invoke(jobs.app, ["failed", "-n", "default"])
+
+        assert result.exit_code == 0
+        assert "failed-job-1" in result.output
+        assert "failed-job-2" in result.output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
 """Tests for devopstoolbox.k8s.utils module."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from devopstoolbox.k8s import utils
-from devopstoolbox.k8s.utils import calculate_cpu_percentage, calculate_memory_percentage, parse_cpu, parse_memory
+from devopstoolbox.k8s.utils import calculate_age, calculate_cpu_percentage, calculate_memory_percentage, parse_cpu, parse_memory
 
 
 class TestParseCpu:
@@ -224,3 +225,40 @@ class TestGetCurrentNamespace:
         result = utils.get_current_namespace()
 
         assert result == "default"
+
+
+class TestCalculateAge:
+    """Tests for calculate_age function."""
+
+    def test_multiple_days(self):
+        """Test age formatting for multiple days."""
+        assert calculate_age(datetime.now(timezone.utc) - timedelta(days=5)) == "5d"
+        assert calculate_age(datetime.now(timezone.utc) - timedelta(days=30)) == "30d"
+
+    def test_single_day(self):
+        """Test age formatting for exactly one day."""
+        assert calculate_age(datetime.now(timezone.utc) - timedelta(days=1)) == "1d"
+
+    def test_hours_and_minutes(self):
+        """Test age formatting for hours and minutes."""
+        assert calculate_age(datetime.now(timezone.utc) - timedelta(hours=1)) == "1h0m"
+        assert calculate_age(datetime.now(timezone.utc) - timedelta(hours=2, minutes=30)) == "2h30m"
+        assert calculate_age(datetime.now(timezone.utc) - timedelta(hours=23, minutes=59)) == "23h59m"
+
+    def test_minutes_and_seconds(self):
+        """Test age formatting for minutes and seconds."""
+        assert calculate_age(datetime.now(timezone.utc) - timedelta(minutes=5)) == "5m0s"
+        assert calculate_age(datetime.now(timezone.utc) - timedelta(minutes=45, seconds=30)) == "45m30s"
+
+    def test_seconds_only(self):
+        """Test age formatting for seconds only."""
+        assert calculate_age(datetime.now(timezone.utc) - timedelta(seconds=30)) == "0m30s"
+        assert calculate_age(datetime.now(timezone.utc) - timedelta(seconds=5)) == "0m5s"
+
+    def test_zero_age(self):
+        """Test age formatting for zero duration."""
+        assert calculate_age(datetime.now(timezone.utc)) == "0m0s"
+
+    def test_days_ignore_hours(self):
+        """Test that days format ignores hours/minutes."""
+        assert calculate_age(datetime.now(timezone.utc) - timedelta(days=2, hours=5, minutes=30)) == "2d"


### PR DESCRIPTION
## Summary
- Add `devopstoolbox k8s jobs list` command for listing Kubernetes jobs
- Support namespace filtering with `-n/--namespace` option
- Support listing across all namespaces with `-A/--all-namespaces` option
- Display job name, namespace, and suspended status

**Work in Progress**

Closes #24

## Test plan
- [x] Add unit tests
- [x] Manual test: `devopstoolbox k8s jobs list`
- [x] Manual test: `devopstoolbox k8s jobs list -n <namespace>`
- [x] Manual test: `devopstoolbox k8s jobs list -A`