### PR TITLE
docs: Add JSON validation command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Python-based CLI toolkit for automating daily DevOps operations.
 ## Features
 
 - **Kubernetes Management**: Manage pods, services, and certificates from the command line
-- **YAML Validation**: Validate YAML files for syntax errors with detailed error reporting
+- **File Validation**: Validate YAML and JSON files for syntax errors with detailed error reporting
 - **Human-readable Output**: Formatted tables with Rich for clear visualization
 - **Metrics Support**: View CPU and memory usage for pods (requires Metrics Server)
 - **Certificate Management**: List and monitor cert-manager certificates
@@ -99,7 +99,7 @@ devopstoolbox k8s certificates list -n cert-manager
 devopstoolbox k8s certificates not-ready -n default
 ```
 
-### YAML Validation
+### File Validation
 
 ```bash
 # Validate a single YAML file
@@ -107,6 +107,12 @@ devopstoolbox validate yaml -f deployment.yaml
 
 # Validate all YAML files in a directory (recursive)
 devopstoolbox validate yaml -d ./manifests
+
+# Validate a single JSON file
+devopstoolbox validate json -f config.json
+
+# Validate all JSON files in a directory (recursive)
+devopstoolbox validate json -d ./configs
 ```
 
 ## Command Reference
@@ -121,6 +127,7 @@ devopstoolbox validate yaml -d ./manifests
 | `devopstoolbox k8s certificates list`      | List cert-manager certificates             |
 | `devopstoolbox k8s certificates not-ready` | List certificates not in Ready state       |
 | `devopstoolbox validate yaml`              | Validate YAML files for syntax errors      |
+| `devopstoolbox validate json`              | Validate JSON files for syntax errors      |
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- Update README to include JSON validation usage examples
- Add `devopstoolbox validate json` to the command reference table
- Rename "YAML Validation" section to "File Validation" to cover both formats

Related to #9

## Test plan
- [x] Verify documentation renders correctly
- [x] All tests pass (96 tests)