### PR TITLE
feat: Add sorting and limit options to pods metrics command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,18 +48,11 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run tests
-        run: pytest --cov --junitxml=junit.xml -o junit_family=legacy
+        run: pytest -v --cov=devopstoolbox --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          report-type: test_results
+          files: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,18 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run tests
-        run: pytest -v --cov=devopstoolbox --cov-report=xml
+        run: pytest --cov --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
+          fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          report-type: test_results
           fail_ci_if_error: false

--- a/src/devopstoolbox/k8s/pods.py
+++ b/src/devopstoolbox/k8s/pods.py
@@ -12,7 +12,7 @@ app = typer.Typer(no_args_is_help=True)
 console = Console()
 
 
-class ResourcesChoices(str, Enum):
+class ResourcesChoice(str, Enum):
     cpu = "cpu"
     memory = "memory"
 
@@ -50,8 +50,8 @@ def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, al
 def metrics(
     namespace: Annotated[str, typer.Option("--namespace", "-n")] = None,
     all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False,
-    sort_by: Annotated[ResourcesChoices, typer.Option("--sort-by", "-s")] = None,
-    limit: Annotated[int, typer.Option("--limit", "-l")] = None,
+    sort_by: Annotated[ResourcesChoice, typer.Option("--sort-by", "-s")] = None,
+    limit: Annotated[int, typer.Option("--limit", "-l", min=1)] = None,
 ):
     """Retrieve CPU and memory resources (requests, limits, usage) for all pods."""
     utils.load_kube_config()
@@ -103,7 +103,7 @@ def metrics(
                 )
 
         if sort_by:
-            sort_key = "cpu_value" if sort_by == ResourcesChoices.cpu else "mem_value"
+            sort_key = "cpu_value" if sort_by == ResourcesChoice.cpu else "mem_value"
             rows.sort(key=lambda x: x[sort_key], reverse=True)
 
         if limit:

--- a/src/devopstoolbox/k8s/pods.py
+++ b/src/devopstoolbox/k8s/pods.py
@@ -1,8 +1,8 @@
+from enum import Enum
 from typing import Annotated
 
 import typer
 from kubernetes import client
-from kubernetes.client import CustomObjectsApi
 from rich.console import Console
 from rich.table import Table
 
@@ -10,6 +10,11 @@ from devopstoolbox.k8s import utils
 
 app = typer.Typer(no_args_is_help=True)
 console = Console()
+
+
+class ResourcesChoices(str, Enum):
+    cpu = "cpu"
+    memory = "memory"
 
 
 @app.command()
@@ -42,29 +47,21 @@ def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, al
 
 
 @app.command()
-def metrics(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
-    """
-    Retrieves CPU and memory resources (requests, limits, usage) for all pods.
-    """
+def metrics(
+    namespace: Annotated[str, typer.Option("--namespace", "-n")] = None,
+    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False,
+    sort_by: Annotated[ResourcesChoices, typer.Option("--sort-by", "-s")] = None,
+    limit: Annotated[int, typer.Option("--limit", "-l")] = None,
+):
+    """Retrieve CPU and memory resources (requests, limits, usage) for all pods."""
     utils.load_kube_config()
     namespace = namespace or utils.get_current_namespace()
     scope = "all namespaces" if all_namespaces else f"namespace {namespace}"
     console.print(f"[bold blue]Listing pod resources in {scope}...[/bold blue]")
 
-    custom_api = CustomObjectsApi()
     metrics_by_container = {}
     try:
-        if all_namespaces:
-            pod_metrics = custom_api.list_cluster_custom_object(group="metrics.k8s.io", version="v1beta1", plural="pods")
-        else:
-            pod_metrics = custom_api.list_namespaced_custom_object(group="metrics.k8s.io", version="v1beta1", namespace=namespace, plural="pods")
-
-        for pod in pod_metrics.get("items", []):
-            pod_name = pod.get("metadata", {}).get("name", "")
-            pod_ns = pod.get("metadata", {}).get("namespace", "")
-            for container in pod.get("containers", []):
-                key = (pod_ns, pod_name, container.get("name"))
-                metrics_by_container[key] = container.get("usage", {})
+        metrics_by_container = utils.fetch_pod_metrics(namespace, all_namespaces)
     except Exception as e:
         console.print("[yellow]Warning: Could not fetch metrics (Metrics Server may not be installed)[/yellow]")
         console.print(f"[dim]Details: {e}[/dim]")
@@ -72,6 +69,45 @@ def metrics(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None,
     try:
         v1 = client.CoreV1Api()
         pods = v1.list_pod_for_all_namespaces(watch=False) if all_namespaces else v1.list_namespaced_pod(namespace, watch=False)
+
+        rows = []
+        for pod in pods.items:
+            pod_ns = pod.metadata.namespace or "-"
+            pod_name = pod.metadata.name
+            for container in pod.spec.containers:
+                resources = container.resources
+                limits = getattr(resources, "limits", None) or {}
+                requests = getattr(resources, "requests", None) or {}
+
+                key = (pod_ns, pod_name, container.name)
+                usage = metrics_by_container.get(key, {})
+                cpu_raw = usage.get("cpu", "0n") if usage else "0n"
+                mem_raw = usage.get("memory", "0Ki") if usage else "0Ki"
+
+                rows.append(
+                    {
+                        "namespace": pod_ns,
+                        "pod": pod_name,
+                        "container": container.name,
+                        "cpu_req": requests.get("cpu", "-"),
+                        "cpu_limit": limits.get("cpu", "-"),
+                        "cpu_usage": utils.parse_cpu(cpu_raw) if usage else "-",
+                        "cpu_percent": utils.calculate_cpu_percentage(usage.get("cpu"), limits.get("cpu")),
+                        "mem_req": requests.get("memory", "-"),
+                        "mem_limit": limits.get("memory", "-"),
+                        "mem_usage": utils.parse_memory(mem_raw) if usage else "-",
+                        "mem_percent": utils.calculate_memory_percentage(usage.get("memory"), limits.get("memory")),
+                        "cpu_value": utils.parse_cpu(cpu_raw, return_number=True) if usage else 0,
+                        "mem_value": utils.parse_memory(mem_raw, return_number=True) if usage else 0,
+                    }
+                )
+
+        if sort_by:
+            sort_key = "cpu_value" if sort_by == ResourcesChoices.cpu else "mem_value"
+            rows.sort(key=lambda x: x[sort_key], reverse=True)
+
+        if limit:
+            rows = rows[:limit]
 
         table = Table(title=f"Pod Resources in {scope}")
         table.add_column("Namespace", style="cyan", justify="center")
@@ -86,31 +122,20 @@ def metrics(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None,
         table.add_column("Mem Usage", style="magenta", justify="center")
         table.add_column("Mem Usage %", style="magenta", justify="center")
 
-        for pod in pods.items:
-            pod_ns = pod.metadata.namespace or "-"
-            pod_name = pod.metadata.name
-            for container in pod.spec.containers:
-                resources = container.resources
-                limits = getattr(resources, "limits", None) or {}
-                requests = getattr(resources, "requests", None) or {}
-
-                key = (pod_ns, pod_name, container.name)
-                usage = metrics_by_container.get(key, {})
-                cpu_percent_usage = utils.calculate_cpu_percentage(usage.get("cpu"), limits.get("cpu"))
-                memory_percent_usage = utils.calculate_memory_percentage(usage.get("memory"), limits.get("memory"))
-                table.add_row(
-                    pod_ns,
-                    pod_name,
-                    container.name,
-                    requests.get("cpu", "-"),
-                    limits.get("cpu", "-"),
-                    utils.parse_cpu(usage.get("cpu", "0n")) if usage else "-",
-                    cpu_percent_usage,
-                    requests.get("memory", "-"),
-                    limits.get("memory", "-"),
-                    utils.parse_memory(usage.get("memory", "0Ki")) if usage else "-",
-                    memory_percent_usage,
-                )
+        for row in rows:
+            table.add_row(
+                row["namespace"],
+                row["pod"],
+                row["container"],
+                row["cpu_req"],
+                row["cpu_limit"],
+                row["cpu_usage"],
+                row["cpu_percent"],
+                row["mem_req"],
+                row["mem_limit"],
+                row["mem_usage"],
+                row["mem_percent"],
+            )
 
         console.print(table)
     except Exception as err:

--- a/src/devopstoolbox/k8s/utils.py
+++ b/src/devopstoolbox/k8s/utils.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 
 import urllib3
 from kubernetes import config
+from kubernetes.client import CustomObjectsApi
 
 # Hide InsecureRequestWarning when CA certificate is not configured
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -113,3 +114,25 @@ def calculate_age(start_time):
         return f"{minutes}m{seconds}s"
     else:
         return f"{seconds}s"
+
+
+def fetch_pod_metrics(namespace: str = None, all_namespaces: bool = False) -> dict:
+    """
+    Fetch pod metrics from the Kubernetes Metrics Server.
+    """
+    custom_api = CustomObjectsApi()
+
+    if all_namespaces:
+        pod_metrics = custom_api.list_cluster_custom_object(group="metrics.k8s.io", version="v1beta1", plural="pods")
+    else:
+        pod_metrics = custom_api.list_namespaced_custom_object(group="metrics.k8s.io", version="v1beta1", namespace=namespace, plural="pods")
+
+    metrics_by_container = {}
+    for pod in pod_metrics.get("items", []):
+        pod_name = pod.get("metadata", {}).get("name", "")
+        pod_ns = pod.get("metadata", {}).get("namespace", "")
+        for container in pod.get("containers", []):
+            key = (pod_ns, pod_name, container.get("name"))
+            metrics_by_container[key] = container.get("usage", {})
+
+    return metrics_by_container

--- a/src/devopstoolbox/k8s/utils.py
+++ b/src/devopstoolbox/k8s/utils.py
@@ -118,7 +118,8 @@ def calculate_age(start_time):
 
 def fetch_pod_metrics(namespace: str = None, all_namespaces: bool = False) -> dict:
     """
-    Fetch pod metrics from the Kubernetes Metrics Server.
+    Retrieves CPU and memory usage metrics for pods from the Kubernetes Metrics Server API.
+    Metrics can be fetched for a specific namespace or across all namespaces in the cluster.
     """
     custom_api = CustomObjectsApi()
 

--- a/tests/test_pods.py
+++ b/tests/test_pods.py
@@ -222,45 +222,49 @@ class TestPodsUnhealthyCommand:
 class TestPodsMetricsCommand:
     """Tests for pods metrics command."""
 
-    @patch("devopstoolbox.k8s.pods.CustomObjectsApi")
-    def test_metrics_displays_cpu_memory(self, mock_custom_api_class):
-        mock_custom_api = Mock()
-        mock_custom_api_class.return_value = mock_custom_api
-        mock_custom_api.list_namespaced_custom_object.return_value = {"items": []}
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_metrics_displays_cpu_memory(self, mock_fetch_metrics, mock_core_api):
+        mock_fetch_metrics.return_value = {}
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+        mock_v1.list_namespaced_pod.return_value = Mock(items=[])
 
         result = runner.invoke(pods.app, ["metrics"])
 
         assert result.exit_code == 0
-
-    @patch("devopstoolbox.k8s.pods.CustomObjectsApi")
-    def test_metrics_handles_empty_response(self, mock_custom_api_class):
-        """Test handling empty metrics response."""
-        mock_custom_api = Mock()
-        mock_custom_api_class.return_value = mock_custom_api
-        mock_custom_api.list_namespaced_custom_object.return_value = {"items": []}
-
-        result = runner.invoke(pods.app, ["metrics"])
-
-        assert result.exit_code == 0
-
-    @patch("devopstoolbox.k8s.pods.CustomObjectsApi")
-    def test_metrics_handles_api_error(self, mock_custom_api_class):
-        """Test handling metrics API errors."""
-        mock_custom_api = Mock()
-        mock_custom_api_class.return_value = mock_custom_api
-        mock_custom_api.list_namespaced_custom_object.side_effect = Exception("Metrics Server not available")
-
-        result = runner.invoke(pods.app, ["metrics"])
-
-        assert result.exit_code == 0
-        assert "Error" in result.output or "Metrics Server" in result.output
 
     @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
-    @patch("devopstoolbox.k8s.pods.CustomObjectsApi")
-    def test_metrics_specific_namespace(self, mock_custom_api_class, mock_core_api, mock_container):
-        mock_custom_api = Mock()
-        mock_custom_api_class.return_value = mock_custom_api
-        mock_custom_api.list_namespaced_custom_object.return_value = {"items": []}
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_metrics_handles_empty_response(self, mock_fetch_metrics, mock_core_api):
+        """Test handling empty metrics response."""
+        mock_fetch_metrics.return_value = {}
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+        mock_v1.list_namespaced_pod.return_value = Mock(items=[])
+
+        result = runner.invoke(pods.app, ["metrics"])
+
+        assert result.exit_code == 0
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_metrics_handles_api_error(self, mock_fetch_metrics, mock_core_api):
+        """Test handling metrics API errors."""
+        mock_fetch_metrics.side_effect = Exception("Metrics Server not available")
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+        mock_v1.list_namespaced_pod.return_value = Mock(items=[])
+
+        result = runner.invoke(pods.app, ["metrics"])
+
+        assert result.exit_code == 0
+        assert "Metrics Server" in result.output
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_metrics_specific_namespace(self, mock_fetch_metrics, mock_core_api, mock_container):
+        mock_fetch_metrics.return_value = {}
 
         mock_v1 = Mock()
         mock_core_api.return_value = mock_v1
@@ -279,11 +283,9 @@ class TestPodsMetricsCommand:
         assert result.exit_code == 0
 
     @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
-    @patch("devopstoolbox.k8s.pods.CustomObjectsApi")
-    def test_metrics_all_namespaces(self, mock_custom_api_class, mock_core_api):
-        mock_custom_api = Mock()
-        mock_custom_api_class.return_value = mock_custom_api
-        mock_custom_api.list_cluster_custom_object.return_value = {"items": []}
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_metrics_all_namespaces(self, mock_fetch_metrics, mock_core_api):
+        mock_fetch_metrics.return_value = {}
 
         mock_v1 = Mock()
         mock_core_api.return_value = mock_v1
@@ -292,15 +294,15 @@ class TestPodsMetricsCommand:
         result = runner.invoke(pods.app, ["metrics", "--all-namespaces"])
 
         assert result.exit_code == 0
-        mock_custom_api.list_cluster_custom_object.assert_called_once()
+        mock_fetch_metrics.assert_called_once()
         mock_v1.list_pod_for_all_namespaces.assert_called_once()
 
     @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
-    @patch("devopstoolbox.k8s.pods.CustomObjectsApi")
-    def test_metrics_displays_all_fields(self, mock_custom_api_class, mock_core_api, mock_container, mock_pod_metrics):
-        mock_custom_api = Mock()
-        mock_custom_api_class.return_value = mock_custom_api
-        mock_custom_api.list_namespaced_custom_object.return_value = mock_pod_metrics
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_metrics_displays_all_fields(self, mock_fetch_metrics, mock_core_api, mock_container):
+        mock_fetch_metrics.return_value = {
+            ("default", "test-pod", "main"): {"cpu": "50m", "memory": "64Mi"}
+        }
 
         mock_v1 = Mock()
         mock_core_api.return_value = mock_v1
@@ -319,5 +321,5 @@ class TestPodsMetricsCommand:
 
         assert result.exit_code == 0
         assert "Pod Resources" in result.output
-        mock_custom_api.list_namespaced_custom_object.assert_called_once()
+        mock_fetch_metrics.assert_called_once()
         mock_v1.list_namespaced_pod.assert_called_once()

--- a/tests/test_pods.py
+++ b/tests/test_pods.py
@@ -300,9 +300,7 @@ class TestPodsMetricsCommand:
     @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
     @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
     def test_metrics_displays_all_fields(self, mock_fetch_metrics, mock_core_api, mock_container):
-        mock_fetch_metrics.return_value = {
-            ("default", "test-pod", "main"): {"cpu": "50m", "memory": "64Mi"}
-        }
+        mock_fetch_metrics.return_value = {("default", "test-pod", "main"): {"cpu": "50m", "memory": "64Mi"}}
 
         mock_v1 = Mock()
         mock_core_api.return_value = mock_v1
@@ -323,3 +321,129 @@ class TestPodsMetricsCommand:
         assert "Pod Resources" in result.output
         mock_fetch_metrics.assert_called_once()
         mock_v1.list_namespaced_pod.assert_called_once()
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_metrics_sort_by_cpu(self, mock_fetch_metrics, mock_core_api):
+        """Test that metrics are sorted by CPU usage in descending order."""
+        mock_fetch_metrics.return_value = {
+            ("default", "aaa", "main"): {"cpu": "50m", "memory": "64Mi"},
+            ("default", "zzz", "main"): {"cpu": "500m", "memory": "32Mi"},
+        }
+
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+
+        # Create two pods with different CPU usage
+        low_cpu_container = Mock()
+        low_cpu_container.name = "main"
+        low_cpu_container.resources.requests = {"cpu": "100m", "memory": "128Mi"}
+        low_cpu_container.resources.limits = {"cpu": "200m", "memory": "256Mi"}
+
+        high_cpu_container = Mock()
+        high_cpu_container.name = "main"
+        high_cpu_container.resources.requests = {"cpu": "100m", "memory": "128Mi"}
+        high_cpu_container.resources.limits = {"cpu": "1000m", "memory": "256Mi"}
+
+        low_cpu_pod = Mock()
+        low_cpu_pod.metadata.namespace = "default"
+        low_cpu_pod.metadata.name = "aaa"
+        low_cpu_pod.spec.containers = [low_cpu_container]
+
+        high_cpu_pod = Mock()
+        high_cpu_pod.metadata.namespace = "default"
+        high_cpu_pod.metadata.name = "zzz"
+        high_cpu_pod.spec.containers = [high_cpu_container]
+
+        mock_pods = Mock()
+        mock_pods.items = [low_cpu_pod, high_cpu_pod]
+        mock_v1.list_namespaced_pod.return_value = mock_pods
+
+        result = runner.invoke(pods.app, ["metrics", "-n", "default", "-s", "cpu"])
+
+        assert result.exit_code == 0
+        high_cpu_pos = result.output.find("500m")
+        low_cpu_pos = result.output.find("50m")
+        assert high_cpu_pos < low_cpu_pos, "High CPU usage should appear first when sorting by CPU"
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_metrics_sort_by_memory(self, mock_fetch_metrics, mock_core_api):
+        """Test that metrics are sorted by memory usage in descending order."""
+        mock_fetch_metrics.return_value = {
+            ("default", "aaa", "main"): {"cpu": "500m", "memory": "64Mi"},
+            ("default", "zzz", "main"): {"cpu": "50m", "memory": "512Mi"},
+        }
+
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+
+        low_mem_container = Mock()
+        low_mem_container.name = "main"
+        low_mem_container.resources.requests = {"cpu": "100m", "memory": "128Mi"}
+        low_mem_container.resources.limits = {"cpu": "200m", "memory": "256Mi"}
+
+        high_mem_container = Mock()
+        high_mem_container.name = "main"
+        high_mem_container.resources.requests = {"cpu": "100m", "memory": "128Mi"}
+        high_mem_container.resources.limits = {"cpu": "200m", "memory": "1Gi"}
+
+        low_mem_pod = Mock()
+        low_mem_pod.metadata.namespace = "default"
+        low_mem_pod.metadata.name = "aaa"
+        low_mem_pod.spec.containers = [low_mem_container]
+
+        high_mem_pod = Mock()
+        high_mem_pod.metadata.namespace = "default"
+        high_mem_pod.metadata.name = "zzz"
+        high_mem_pod.spec.containers = [high_mem_container]
+
+        mock_pods = Mock()
+        mock_pods.items = [low_mem_pod, high_mem_pod]
+        mock_v1.list_namespaced_pod.return_value = mock_pods
+
+        result = runner.invoke(pods.app, ["metrics", "-n", "default", "-s", "memory"])
+
+        assert result.exit_code == 0
+        high_mem_pos = result.output.find("512")
+        low_mem_pos = result.output.find("64")
+        assert high_mem_pos < low_mem_pos, "High memory usage should appear first when sorting by memory"
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_metrics_limit_results(self, mock_fetch_metrics, mock_core_api):
+        """Test that limit option restricts the number of results."""
+        mock_fetch_metrics.return_value = {
+            ("default", "aaa", "main"): {"cpu": "100m", "memory": "64Mi"},
+            ("default", "bbb", "main"): {"cpu": "200m", "memory": "128Mi"},
+            ("default", "ccc", "main"): {"cpu": "300m", "memory": "256Mi"},
+        }
+
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+
+        pods_list = []
+        for name in ["aaa", "bbb", "ccc"]:
+            container = Mock()
+            container.name = "main"
+            container.resources.requests = {"cpu": "100m", "memory": "128Mi"}
+            container.resources.limits = {"cpu": "500m", "memory": "512Mi"}
+
+            pod = Mock()
+            pod.metadata.namespace = "default"
+            pod.metadata.name = name
+            pod.spec.containers = [container]
+            pods_list.append(pod)
+
+        mock_pods = Mock()
+        mock_pods.items = pods_list
+        mock_v1.list_namespaced_pod.return_value = mock_pods
+
+        result = runner.invoke(pods.app, ["metrics", "-n", "default", "-s", "cpu", "-l", "2"])
+
+        assert result.exit_code == 0
+        assert "300m" in result.output
+        assert "200m" in result.output
+        output_lines = result.output.split("\n")
+        data_rows = [line for line in output_lines if "100m" in line and "500m" not in line]
+        assert len(data_rows) == 0, "Pod with 100m CPU should be excluded by limit"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,8 @@
 from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
+import pytest
+
 from devopstoolbox.k8s import utils
 from devopstoolbox.k8s.utils import calculate_age, calculate_cpu_percentage, calculate_memory_percentage, fetch_pod_metrics, parse_cpu, parse_memory
 
@@ -340,11 +342,8 @@ class TestFetchPodMetrics:
         mock_custom_api_class.return_value = mock_custom_api
         mock_custom_api.list_namespaced_custom_object.side_effect = Exception("Metrics Server not available")
 
-        try:
+        with pytest.raises(Exception, match="Metrics Server not available"):
             fetch_pod_metrics("default", all_namespaces=False)
-            assert False, "Expected exception to be raised"
-        except Exception as e:
-            assert "Metrics Server not available" in str(e)
 
     @patch("devopstoolbox.k8s.utils.CustomObjectsApi")
     def test_fetch_metrics_multiple_pods(self, mock_custom_api_class):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -292,9 +292,7 @@ class TestFetchPodMetrics:
         assert ("default", "test-pod", "sidecar") in result
         assert result[("default", "test-pod", "main")] == {"cpu": "100m", "memory": "128Mi"}
         assert result[("default", "test-pod", "sidecar")] == {"cpu": "50m", "memory": "64Mi"}
-        mock_custom_api.list_namespaced_custom_object.assert_called_once_with(
-            group="metrics.k8s.io", version="v1beta1", namespace="default", plural="pods"
-        )
+        mock_custom_api.list_namespaced_custom_object.assert_called_once_with(group="metrics.k8s.io", version="v1beta1", namespace="default", plural="pods")
 
     @patch("devopstoolbox.k8s.utils.CustomObjectsApi")
     def test_fetch_metrics_all_namespaces(self, mock_custom_api_class):
@@ -320,9 +318,7 @@ class TestFetchPodMetrics:
         assert ("ns2", "pod-2", "app") in result
         assert result[("ns1", "pod-1", "app")] == {"cpu": "200m", "memory": "256Mi"}
         assert result[("ns2", "pod-2", "app")] == {"cpu": "300m", "memory": "512Mi"}
-        mock_custom_api.list_cluster_custom_object.assert_called_once_with(
-            group="metrics.k8s.io", version="v1beta1", plural="pods"
-        )
+        mock_custom_api.list_cluster_custom_object.assert_called_once_with(group="metrics.k8s.io", version="v1beta1", plural="pods")
 
     @patch("devopstoolbox.k8s.utils.CustomObjectsApi")
     def test_fetch_metrics_empty_response(self, mock_custom_api_class):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,10 @@
 """Tests for devopstoolbox.k8s.utils module."""
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from devopstoolbox.k8s import utils
-from devopstoolbox.k8s.utils import calculate_age, calculate_cpu_percentage, calculate_memory_percentage, parse_cpu, parse_memory
+from devopstoolbox.k8s.utils import calculate_age, calculate_cpu_percentage, calculate_memory_percentage, fetch_pod_metrics, parse_cpu, parse_memory
 
 
 class TestParseCpu:
@@ -262,3 +262,115 @@ class TestCalculateAge:
     def test_days_ignore_hours(self):
         """Test that days format ignores hours/minutes."""
         assert calculate_age(datetime.now(timezone.utc) - timedelta(days=2, hours=5, minutes=30)) == "2d"
+
+
+class TestFetchPodMetrics:
+    """Tests for fetch_pod_metrics function."""
+
+    @patch("devopstoolbox.k8s.utils.CustomObjectsApi")
+    def test_fetch_metrics_single_namespace(self, mock_custom_api_class):
+        """Test fetching metrics for a single namespace."""
+        mock_custom_api = Mock()
+        mock_custom_api_class.return_value = mock_custom_api
+        mock_custom_api.list_namespaced_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "test-pod", "namespace": "default"},
+                    "containers": [
+                        {"name": "main", "usage": {"cpu": "100m", "memory": "128Mi"}},
+                        {"name": "sidecar", "usage": {"cpu": "50m", "memory": "64Mi"}},
+                    ],
+                }
+            ]
+        }
+
+        result = fetch_pod_metrics("default", all_namespaces=False)
+
+        assert ("default", "test-pod", "main") in result
+        assert ("default", "test-pod", "sidecar") in result
+        assert result[("default", "test-pod", "main")] == {"cpu": "100m", "memory": "128Mi"}
+        assert result[("default", "test-pod", "sidecar")] == {"cpu": "50m", "memory": "64Mi"}
+        mock_custom_api.list_namespaced_custom_object.assert_called_once_with(
+            group="metrics.k8s.io", version="v1beta1", namespace="default", plural="pods"
+        )
+
+    @patch("devopstoolbox.k8s.utils.CustomObjectsApi")
+    def test_fetch_metrics_all_namespaces(self, mock_custom_api_class):
+        """Test fetching metrics across all namespaces."""
+        mock_custom_api = Mock()
+        mock_custom_api_class.return_value = mock_custom_api
+        mock_custom_api.list_cluster_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "pod-1", "namespace": "ns1"},
+                    "containers": [{"name": "app", "usage": {"cpu": "200m", "memory": "256Mi"}}],
+                },
+                {
+                    "metadata": {"name": "pod-2", "namespace": "ns2"},
+                    "containers": [{"name": "app", "usage": {"cpu": "300m", "memory": "512Mi"}}],
+                },
+            ]
+        }
+
+        result = fetch_pod_metrics(namespace=None, all_namespaces=True)
+
+        assert ("ns1", "pod-1", "app") in result
+        assert ("ns2", "pod-2", "app") in result
+        assert result[("ns1", "pod-1", "app")] == {"cpu": "200m", "memory": "256Mi"}
+        assert result[("ns2", "pod-2", "app")] == {"cpu": "300m", "memory": "512Mi"}
+        mock_custom_api.list_cluster_custom_object.assert_called_once_with(
+            group="metrics.k8s.io", version="v1beta1", plural="pods"
+        )
+
+    @patch("devopstoolbox.k8s.utils.CustomObjectsApi")
+    def test_fetch_metrics_empty_response(self, mock_custom_api_class):
+        """Test handling empty metrics response."""
+        mock_custom_api = Mock()
+        mock_custom_api_class.return_value = mock_custom_api
+        mock_custom_api.list_namespaced_custom_object.return_value = {"items": []}
+
+        result = fetch_pod_metrics("default", all_namespaces=False)
+
+        assert result == {}
+
+    @patch("devopstoolbox.k8s.utils.CustomObjectsApi")
+    def test_fetch_metrics_api_error(self, mock_custom_api_class):
+        """Test that API errors are propagated."""
+        mock_custom_api = Mock()
+        mock_custom_api_class.return_value = mock_custom_api
+        mock_custom_api.list_namespaced_custom_object.side_effect = Exception("Metrics Server not available")
+
+        try:
+            fetch_pod_metrics("default", all_namespaces=False)
+            assert False, "Expected exception to be raised"
+        except Exception as e:
+            assert "Metrics Server not available" in str(e)
+
+    @patch("devopstoolbox.k8s.utils.CustomObjectsApi")
+    def test_fetch_metrics_multiple_pods(self, mock_custom_api_class):
+        """Test fetching metrics for multiple pods."""
+        mock_custom_api = Mock()
+        mock_custom_api_class.return_value = mock_custom_api
+        mock_custom_api.list_namespaced_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "web", "namespace": "default"},
+                    "containers": [{"name": "nginx", "usage": {"cpu": "50m", "memory": "64Mi"}}],
+                },
+                {
+                    "metadata": {"name": "api", "namespace": "default"},
+                    "containers": [{"name": "app", "usage": {"cpu": "150m", "memory": "256Mi"}}],
+                },
+                {
+                    "metadata": {"name": "db", "namespace": "default"},
+                    "containers": [{"name": "postgres", "usage": {"cpu": "500m", "memory": "1Gi"}}],
+                },
+            ]
+        }
+
+        result = fetch_pod_metrics("default", all_namespaces=False)
+
+        assert len(result) == 3
+        assert result[("default", "web", "nginx")] == {"cpu": "50m", "memory": "64Mi"}
+        assert result[("default", "api", "app")] == {"cpu": "150m", "memory": "256Mi"}
+        assert result[("default", "db", "postgres")] == {"cpu": "500m", "memory": "1Gi"}


### PR DESCRIPTION
## Summary

- Add `--sort-by/-s` option to sort pods by CPU or memory usage
- Add `--limit/-l` option to limit results to top N pods
- Extract `fetch_pod_metrics()` helper function to `utils.py` for code reuse
- Update tests to verify sorting and limiting functionality

Closes #12

## Usage Examples

```bash
# Show all pod metrics (original behavior)
devopstoolbox k8s pods metrics

# Show top 10 pods sorted by CPU usage
devopstoolbox k8s pods metrics --sort-by cpu --limit 10

# Show top 5 pods by memory across all namespaces
devopstoolbox k8s pods metrics -A -s memory -l 5
```

## Test plan

- [x] All existing tests pass (134 tests)
- [x] New tests for sorting by CPU
- [x] New tests for sorting by memory
- [x] New tests for limit functionality