### PR TITLE
Add pods overprovisioned command to detect unused resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ devopstoolbox k8s pods metrics -A --sort-by cpu
 
 # Show top 10 pods by memory usage
 devopstoolbox k8s pods metrics -A --sort-by memory --limit 10
+
+# Find overprovisioned pods (usage below 50% of request)
+devopstoolbox k8s pods overprovisioned -n default
+
+# Find overprovisioned pods with custom threshold (30%)
+devopstoolbox k8s pods overprovisioned -A --threshold 30
+
+# Find overprovisioned pods sorted by CPU, limit to top 10
+devopstoolbox k8s pods overprovisioned -A --sort-by cpu --limit 10
 ```
 
 ### Services Management
@@ -176,6 +185,7 @@ devopstoolbox misc validate json -d ./configs
 | `devopstoolbox k8s pods list`              | List pods with status and restart count    |
 | `devopstoolbox k8s pods metrics`           | Show CPU and memory usage per container    |
 | `devopstoolbox k8s pods unhealthy`         | List pods not in Running/Succeeded state   |
+| `devopstoolbox k8s pods overprovisioned`   | Find pods with resources below threshold   |
 | **Kubernetes - Services**                  |                                            |
 | `devopstoolbox k8s services list`          | List services with type and traffic policy |
 | **Kubernetes - Jobs**                      |                                            |

--- a/src/devopstoolbox/k8s/certificates.py
+++ b/src/devopstoolbox/k8s/certificates.py
@@ -12,7 +12,10 @@ console = Console()
 
 
 @app.command()
-def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
+def list(
+    namespace: Annotated[str, typer.Option("--namespace", "-n", help="Kubernetes namespace to query")] = None,
+    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A", help="Query all namespaces")] = False,
+):
     """List cert-manager certificates with renewal time and status."""
     utils.load_kube_config()
     namespace = namespace or utils.get_current_namespace()
@@ -46,7 +49,10 @@ def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, al
 
 
 @app.command()
-def not_ready(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
+def not_ready(
+    namespace: Annotated[str, typer.Option("--namespace", "-n", help="Kubernetes namespace to query")] = None,
+    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A", help="Query all namespaces")] = False,
+):
     """List certificates that are not in Ready state."""
     utils.load_kube_config()
     namespace = namespace or utils.get_current_namespace()

--- a/src/devopstoolbox/k8s/jobs.py
+++ b/src/devopstoolbox/k8s/jobs.py
@@ -12,8 +12,11 @@ console = Console()
 
 
 @app.command()
-def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
-    """List Jobs"""
+def list(
+    namespace: Annotated[str, typer.Option("--namespace", "-n", help="Kubernetes namespace to query")] = None,
+    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A", help="Query all namespaces")] = False,
+):
+    """List all jobs with status and age."""
     utils.load_kube_config()
     namespace = namespace or utils.get_current_namespace()
     scope = "all namespaces" if all_namespaces else f"namespace {namespace}"
@@ -48,8 +51,11 @@ def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, al
 
 
 @app.command()
-def failed(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
-    """List only failed Jobs"""
+def failed(
+    namespace: Annotated[str, typer.Option("--namespace", "-n", help="Kubernetes namespace to query")] = None,
+    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A", help="Query all namespaces")] = False,
+):
+    """List only failed jobs with error messages."""
     utils.load_kube_config()
     namespace = namespace or utils.get_current_namespace()
     scope = "all namespaces" if all_namespaces else f"namespace {namespace}"

--- a/src/devopstoolbox/k8s/pods.py
+++ b/src/devopstoolbox/k8s/pods.py
@@ -65,6 +65,10 @@ def _fetch_pod_resource_data(namespace: str, all_namespaces: bool) -> tuple[list
             cpu_request_percent = utils.calculate_cpu_percentage(usage.get("cpu"), requests.get("cpu"))
             mem_request_percent = utils.calculate_memory_percentage(usage.get("memory"), requests.get("memory"))
 
+            status = pod.status.phase
+            restart_count = sum((status.restart_count or 0) for status in pod.status.container_statuses or [])
+            age = utils.calculate_age(pod.status.start_time)
+
             rows.append(
                 {
                     "namespace": pod_ns,
@@ -84,6 +88,9 @@ def _fetch_pod_resource_data(namespace: str, all_namespaces: bool) -> tuple[list
                     "mem_provisioned_value": mem_request_percent,
                     "cpu_value": utils.parse_cpu(cpu_raw, return_number=True) if usage else 0,
                     "mem_value": utils.parse_memory(mem_raw, return_number=True) if usage else 0,
+                    "statuses": status,
+                    "restart_count": f"{restart_count}",
+                    "age": age,
                 }
             )
 
@@ -114,14 +121,9 @@ def _sort_and_limit_rows(rows: list[dict], sort_by: ResourcesChoice | None, limi
 @app.command()
 def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
     """List pods"""
-    utils.load_kube_config()
-    namespace = namespace or utils.get_current_namespace()
-    scope = "all namespaces" if all_namespaces else f"namespace {namespace}"
-    console.print(f"[bold blue]Listing pods in {scope}...[/bold blue]")
 
     try:
-        v1 = client.CoreV1Api()
-        pods = v1.list_pod_for_all_namespaces(watch=False) if all_namespaces else v1.list_namespaced_pod(namespace, watch=False)
+        rows, scope, _ = _fetch_pod_resource_data(namespace, all_namespaces)
 
         table = Table(title=f"Pods in {scope}")
         table.add_column("Namespace", style="cyan", justify="center")
@@ -130,10 +132,8 @@ def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, al
         table.add_column("Age", justify="center")
         table.add_column("Status", style="green", justify="center")
 
-        for pod in pods.items:
-            statuses = pod.status.container_statuses or []
-            restart_count = sum((status.restart_count or 0) for status in statuses)
-            table.add_row(pod.metadata.namespace or "-", pod.metadata.name, str(restart_count), utils.calculate_age(pod.status.start_time), pod.status.phase)
+        for row in rows:
+            table.add_row(row["namespace"], row["pod"], row["restart_count"], row["age"], row["statuses"])
 
         console.print(table)
     except Exception as err:

--- a/src/devopstoolbox/k8s/pods.py
+++ b/src/devopstoolbox/k8s/pods.py
@@ -238,7 +238,7 @@ def overprovisioned(
 
         rows = _sort_and_limit_rows(rows, sort_by, limit)
 
-        table = Table(title=f"Overprovisioned Pods in {scope} and Threshold: {threshold}%")
+        table = Table(title=f"Overprovisioned Pods in {scope} (Threshold: {threshold}%)")
         table.add_column("Namespace", style="cyan", justify="center")
         table.add_column("Pod Name", style="cyan", justify="center")
         table.add_column("Container", style="cyan", justify="center")

--- a/src/devopstoolbox/k8s/pods.py
+++ b/src/devopstoolbox/k8s/pods.py
@@ -182,9 +182,13 @@ def overprovisioned(
     all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False,
     sort_by: Annotated[ResourcesChoice, typer.Option("--sort-by", "-s")] = None,
     limit: Annotated[int, typer.Option("--limit", "-l", min=1)] = None,
-    threshold: Annotated[float, typer.Option("--threshold", "-th", min=0)] = 20,
+    threshold: Annotated[float, typer.Option("--threshold", "-th", min=0)] = 50,
 ):
-    """Retrieve CPU and memory resources (requests, limits, usage) for all pods."""
+    """Identify pods with overprovisioned CPU and memory resources.
+
+    Compares resource requests vs actual usage from Metrics Server.
+    Flags pods where usage is below the specified threshold percentage of requests.
+    """
     utils.load_kube_config()
     namespace = namespace or utils.get_current_namespace()
     scope = "all namespaces" if all_namespaces else f"namespace {namespace}"

--- a/src/devopstoolbox/k8s/pods.py
+++ b/src/devopstoolbox/k8s/pods.py
@@ -246,12 +246,12 @@ def overprovisioned(
         table.add_column("CPU Limit", style="yellow", justify="center")
         table.add_column("CPU Usage", style="magenta", justify="center")
         table.add_column("CPU Usage %", style="magenta", justify="center")
-        table.add_column("CPU From Request %", style="magenta", justify="center")
+        table.add_column("CPU % of Request", style="magenta", justify="center")
         table.add_column("Mem Req", style="green", justify="center")
         table.add_column("Mem Limit", style="yellow", justify="center")
         table.add_column("Mem Usage", style="magenta", justify="center")
         table.add_column("Mem Usage %", style="magenta", justify="center")
-        table.add_column("Mem From Request %", style="magenta", justify="center")
+        table.add_column("Mem % of Request", style="magenta", justify="center")
 
         for row in rows:
             table.add_row(

--- a/src/devopstoolbox/k8s/pods.py
+++ b/src/devopstoolbox/k8s/pods.py
@@ -119,8 +119,11 @@ def _sort_and_limit_rows(rows: list[dict], sort_by: ResourcesChoice | None, limi
 
 
 @app.command()
-def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
-    """List pods"""
+def list(
+    namespace: Annotated[str, typer.Option("--namespace", "-n", help="Kubernetes namespace to query")] = None,
+    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A", help="Query all namespaces")] = False,
+):
+    """List all pods with status, restart count, and age."""
 
     try:
         rows, scope, _ = _fetch_pod_resource_data(namespace, all_namespaces)
@@ -142,12 +145,12 @@ def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, al
 
 @app.command()
 def metrics(
-    namespace: Annotated[str, typer.Option("--namespace", "-n")] = None,
-    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False,
-    sort_by: Annotated[ResourcesChoice, typer.Option("--sort-by", "-s")] = None,
-    limit: Annotated[int, typer.Option("--limit", "-l", min=1)] = None,
+    namespace: Annotated[str, typer.Option("--namespace", "-n", help="Kubernetes namespace to query")] = None,
+    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A", help="Query all namespaces")] = False,
+    sort_by: Annotated[ResourcesChoice, typer.Option("--sort-by", "-s", help="Sort results by cpu or memory usage")] = None,
+    limit: Annotated[int, typer.Option("--limit", "-l", min=1, help="Limit the number of results")] = None,
 ):
-    """Retrieve CPU and memory resources (requests, limits, usage) for all pods."""
+    """Show CPU and memory metrics (requests, limits, usage) for all pods."""
     try:
         rows, scope, _ = _fetch_pod_resource_data(namespace, all_namespaces)
         console.print(f"[bold blue]Listing pod resources in {scope}...[/bold blue]")
@@ -188,10 +191,11 @@ def metrics(
 
 
 @app.command()
-def unhealthy(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
-    """
-    List pods with issues (not in Running or Succeeded state).
-    """
+def unhealthy(
+    namespace: Annotated[str, typer.Option("--namespace", "-n", help="Kubernetes namespace to query")] = None,
+    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A", help="Query all namespaces")] = False,
+):
+    """List pods not in Running or Succeeded state."""
     utils.load_kube_config()
     namespace = namespace or utils.get_current_namespace()
     scope = "all namespaces" if all_namespaces else f"namespace {namespace}"
@@ -221,17 +225,13 @@ def unhealthy(namespace: Annotated[str, typer.Option("--namespace", "-n")] = Non
 
 @app.command()
 def overprovisioned(
-    namespace: Annotated[str, typer.Option("--namespace", "-n")] = None,
-    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False,
-    sort_by: Annotated[ResourcesChoice, typer.Option("--sort-by", "-s")] = None,
-    limit: Annotated[int, typer.Option("--limit", "-l", min=1)] = None,
-    threshold: Annotated[float, typer.Option("--threshold", "-th", min=0)] = 50,
+    namespace: Annotated[str, typer.Option("--namespace", "-n", help="Kubernetes namespace to query")] = None,
+    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A", help="Query all namespaces")] = False,
+    sort_by: Annotated[ResourcesChoice, typer.Option("--sort-by", "-s", help="Sort results by cpu or memory usage")] = None,
+    limit: Annotated[int, typer.Option("--limit", "-l", min=1, help="Limit the number of results")] = None,
+    threshold: Annotated[float, typer.Option("--threshold", "-th", min=0, help="Usage threshold percentage (default: 50)")] = 50,
 ):
-    """Identify pods with overprovisioned CPU and memory resources.
-
-    Compares resource requests vs actual usage from Metrics Server.
-    Flags pods where usage is below the specified threshold percentage of requests.
-    """
+    """Find pods where resource usage is below threshold percentage of requests."""
     try:
         rows, scope, _ = _fetch_pod_resource_data(namespace, all_namespaces)
         rows = [row for row in rows if row["cpu_provisioned_value"] < threshold or row["mem_provisioned_value"] < threshold]

--- a/src/devopstoolbox/k8s/pods.py
+++ b/src/devopstoolbox/k8s/pods.py
@@ -17,6 +17,100 @@ class ResourcesChoice(str, Enum):
     memory = "memory"
 
 
+def _fetch_pod_resource_data(namespace: str, all_namespaces: bool) -> tuple[list[dict], str, bool]:
+    """Fetch pod resource data including metrics.
+
+    Args:
+        namespace: The namespace to query.
+        all_namespaces: If True, query all namespaces.
+
+    Returns:
+        A tuple of (rows, scope, metrics_available) where:
+        - rows: List of dicts with resource data for each container
+        - scope: String describing the scope (for display)
+        - metrics_available: Whether metrics were successfully fetched
+    """
+    utils.load_kube_config()
+    namespace = namespace or utils.get_current_namespace()
+    scope = "all namespaces" if all_namespaces else f"namespace {namespace}"
+
+    metrics_by_container = {}
+    metrics_available = True
+    try:
+        metrics_by_container = utils.fetch_pod_metrics(namespace, all_namespaces)
+    except Exception as e:
+        metrics_available = False
+        console.print("[yellow]Warning: Could not fetch metrics (Metrics Server may not be installed)[/yellow]")
+        console.print(f"[dim]Details: {e}[/dim]")
+
+    v1 = client.CoreV1Api()
+    pods = v1.list_pod_for_all_namespaces(watch=False) if all_namespaces else v1.list_namespaced_pod(namespace, watch=False)
+
+    rows = []
+    for pod in pods.items:
+        pod_ns = pod.metadata.namespace or "-"
+        pod_name = pod.metadata.name
+        for container in pod.spec.containers:
+            resources = container.resources
+            limits = getattr(resources, "limits", None) or {}
+            requests = getattr(resources, "requests", None) or {}
+
+            key = (pod_ns, pod_name, container.name)
+            usage = metrics_by_container.get(key, {})
+            cpu_raw = usage.get("cpu", "0n") if usage else "0n"
+            mem_raw = usage.get("memory", "0Ki") if usage else "0Ki"
+
+            cpu_limit_percent = utils.calculate_cpu_percentage(usage.get("cpu"), limits.get("cpu"))
+            mem_limit_percent = utils.calculate_memory_percentage(usage.get("memory"), limits.get("memory"))
+            cpu_request_percent = utils.calculate_cpu_percentage(usage.get("cpu"), requests.get("cpu"))
+            mem_request_percent = utils.calculate_memory_percentage(usage.get("memory"), requests.get("memory"))
+
+            rows.append(
+                {
+                    "namespace": pod_ns,
+                    "pod": pod_name,
+                    "container": container.name,
+                    "cpu_req": requests.get("cpu", "-"),
+                    "cpu_limit": limits.get("cpu", "-"),
+                    "cpu_usage": utils.parse_cpu(cpu_raw) if usage else "-",
+                    "cpu_percent": f"{cpu_limit_percent:.2f}%",
+                    "cpu_provisioned": f"{cpu_request_percent:.2f}%",
+                    "cpu_provisioned_value": cpu_request_percent,
+                    "mem_req": requests.get("memory", "-"),
+                    "mem_limit": limits.get("memory", "-"),
+                    "mem_usage": utils.parse_memory(mem_raw) if usage else "-",
+                    "mem_percent": f"{mem_limit_percent:.2f}%",
+                    "mem_provisioned": f"{mem_request_percent:.2f}%",
+                    "mem_provisioned_value": mem_request_percent,
+                    "cpu_value": utils.parse_cpu(cpu_raw, return_number=True) if usage else 0,
+                    "mem_value": utils.parse_memory(mem_raw, return_number=True) if usage else 0,
+                }
+            )
+
+    return rows, scope, metrics_available
+
+
+def _sort_and_limit_rows(rows: list[dict], sort_by: ResourcesChoice | None, limit: int | None) -> list[dict]:
+    """Sort and limit rows based on parameters.
+
+    Args:
+        rows: List of resource data rows.
+        sort_by: Sort by cpu or memory.
+        limit: Maximum number of rows to return.
+
+    Returns:
+        Sorted and limited list of rows.
+    """
+    if sort_by:
+        sort_key = "cpu_value" if sort_by == ResourcesChoice.cpu else "mem_value"
+        rows = sorted(rows, key=lambda x: x[sort_key], reverse=True)
+
+    if limit:
+        rows = rows[:limit]
+
+    return rows
+
+
 @app.command()
 def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
     """List pods"""
@@ -54,62 +148,11 @@ def metrics(
     limit: Annotated[int, typer.Option("--limit", "-l", min=1)] = None,
 ):
     """Retrieve CPU and memory resources (requests, limits, usage) for all pods."""
-    utils.load_kube_config()
-    namespace = namespace or utils.get_current_namespace()
-    scope = "all namespaces" if all_namespaces else f"namespace {namespace}"
-    console.print(f"[bold blue]Listing pod resources in {scope}...[/bold blue]")
-
-    metrics_by_container = {}
     try:
-        metrics_by_container = utils.fetch_pod_metrics(namespace, all_namespaces)
-    except Exception as e:
-        console.print("[yellow]Warning: Could not fetch metrics (Metrics Server may not be installed)[/yellow]")
-        console.print(f"[dim]Details: {e}[/dim]")
+        rows, scope, _ = _fetch_pod_resource_data(namespace, all_namespaces)
+        console.print(f"[bold blue]Listing pod resources in {scope}...[/bold blue]")
 
-    try:
-        v1 = client.CoreV1Api()
-        pods = v1.list_pod_for_all_namespaces(watch=False) if all_namespaces else v1.list_namespaced_pod(namespace, watch=False)
-
-        rows = []
-        for pod in pods.items:
-            pod_ns = pod.metadata.namespace or "-"
-            pod_name = pod.metadata.name
-            for container in pod.spec.containers:
-                resources = container.resources
-                limits = getattr(resources, "limits", None) or {}
-                requests = getattr(resources, "requests", None) or {}
-
-                key = (pod_ns, pod_name, container.name)
-                usage = metrics_by_container.get(key, {})
-                cpu_raw = usage.get("cpu", "0n") if usage else "0n"
-                mem_raw = usage.get("memory", "0Ki") if usage else "0Ki"
-                cpu_percent = utils.calculate_cpu_percentage(usage.get("cpu"), limits.get("cpu"))
-                mem_percent = utils.calculate_memory_percentage(usage.get("memory"), limits.get("memory"))
-
-                rows.append(
-                    {
-                        "namespace": pod_ns,
-                        "pod": pod_name,
-                        "container": container.name,
-                        "cpu_req": requests.get("cpu", "-"),
-                        "cpu_limit": limits.get("cpu", "-"),
-                        "cpu_usage": utils.parse_cpu(cpu_raw) if usage else "-",
-                        "cpu_percent": f"{cpu_percent:.2f}%",
-                        "mem_req": requests.get("memory", "-"),
-                        "mem_limit": limits.get("memory", "-"),
-                        "mem_usage": utils.parse_memory(mem_raw) if usage else "-",
-                        "mem_percent": f"{mem_percent:.2f}%",
-                        "cpu_value": utils.parse_cpu(cpu_raw, return_number=True) if usage else 0,
-                        "mem_value": utils.parse_memory(mem_raw, return_number=True) if usage else 0,
-                    }
-                )
-
-        if sort_by:
-            sort_key = "cpu_value" if sort_by == ResourcesChoice.cpu else "mem_value"
-            rows.sort(key=lambda x: x[sort_key], reverse=True)
-
-        if limit:
-            rows = rows[:limit]
+        rows = _sort_and_limit_rows(rows, sort_by, limit)
 
         table = Table(title=f"Pod Resources in {scope}")
         table.add_column("Namespace", style="cyan", justify="center")
@@ -189,78 +232,13 @@ def overprovisioned(
     Compares resource requests vs actual usage from Metrics Server.
     Flags pods where usage is below the specified threshold percentage of requests.
     """
-    utils.load_kube_config()
-    namespace = namespace or utils.get_current_namespace()
-    scope = "all namespaces" if all_namespaces else f"namespace {namespace}"
-    console.print(f"[bold blue]Listing pod resources in {scope}...[/bold blue]")
-
-    metrics_by_container = {}
     try:
-        metrics_by_container = utils.fetch_pod_metrics(namespace, all_namespaces)
-    except Exception as e:
-        console.print("[yellow]Warning: Could not fetch metrics (Metrics Server may not be installed)[/yellow]")
-        console.print(f"[dim]Details: {e}[/dim]")
+        rows, scope, _ = _fetch_pod_resource_data(namespace, all_namespaces)
+        rows = [row for row in rows if row["cpu_provisioned_value"] < threshold or row["mem_provisioned_value"] < threshold]
 
-    try:
-        v1 = client.CoreV1Api()
-        pods = v1.list_pod_for_all_namespaces(watch=False) if all_namespaces else v1.list_namespaced_pod(namespace, watch=False)
+        rows = _sort_and_limit_rows(rows, sort_by, limit)
 
-        rows = []
-        for pod in pods.items:
-            pod_ns = pod.metadata.namespace or "-"
-            pod_name = pod.metadata.name
-            for container in pod.spec.containers:
-                resources = container.resources
-                limits = getattr(resources, "limits", None) or {}
-                requests = getattr(resources, "requests", None) or {}
-                key = (pod_ns, pod_name, container.name)
-                usage = metrics_by_container.get(key, {})
-                cpu_raw = usage.get("cpu", "0n") if usage else "0n"
-                mem_raw = usage.get("memory", "0Ki") if usage else "0Ki"
-
-                cpu_req = requests.get("cpu", "-")
-                cpu_limit = limits.get("cpu", "-")
-                cpu_usage = utils.parse_cpu(cpu_raw) if usage else "-"
-                cpu_percent = f"{utils.calculate_cpu_percentage(usage.get('cpu'), limits.get('cpu')):.2f}%"
-                mem_req = requests.get("memory", "-")
-                mem_limit = limits.get("memory", "-")
-                mem_usage = utils.parse_memory(mem_raw) if usage else "-"
-                mem_percent = f"{utils.calculate_memory_percentage(usage.get('memory'), limits.get('memory')):.2f}%"
-                cpu_value = utils.parse_cpu(cpu_raw, return_number=True) if usage else 0
-                mem_value = utils.parse_memory(mem_raw, return_number=True) if usage else 0
-
-                cpu_provisioned = utils.calculate_cpu_percentage(usage.get("cpu"), requests.get("cpu"))
-                memory_provisioned = utils.calculate_memory_percentage(usage.get("memory"), requests.get("memory"))
-
-                if cpu_provisioned < threshold or memory_provisioned < threshold:
-                    rows.append(
-                        {
-                            "namespace": pod_ns,
-                            "pod": pod_name,
-                            "container": container.name,
-                            "cpu_req": cpu_req,
-                            "cpu_limit": cpu_limit,
-                            "cpu_usage": cpu_usage,
-                            "cpu_percent": cpu_percent,
-                            "cpu_provisioned": f"{cpu_provisioned:.2f}%",
-                            "mem_req": mem_req,
-                            "mem_limit": mem_limit,
-                            "mem_usage": mem_usage,
-                            "mem_percent": mem_percent,
-                            "memory_provisioned": f"{memory_provisioned:.2f}%",
-                            "cpu_value": cpu_value,
-                            "mem_value": mem_value,
-                        }
-                    )
-
-        if sort_by:
-            sort_key = "cpu_value" if sort_by == ResourcesChoice.cpu else "mem_value"
-            rows.sort(key=lambda x: x[sort_key], reverse=True)
-
-        if limit:
-            rows = rows[:limit]
-
-        table = Table(title=f"Pod Resources in {scope}")
+        table = Table(title=f"Overprovisioned Pods in {scope} and Threshold: {threshold}%")
         table.add_column("Namespace", style="cyan", justify="center")
         table.add_column("Pod Name", style="cyan", justify="center")
         table.add_column("Container", style="cyan", justify="center")
@@ -289,7 +267,7 @@ def overprovisioned(
                 row["mem_limit"],
                 row["mem_usage"],
                 row["mem_percent"],
-                row["memory_provisioned"],
+                row["mem_provisioned"],
             )
 
         console.print(table)

--- a/src/devopstoolbox/k8s/pods.py
+++ b/src/devopstoolbox/k8s/pods.py
@@ -83,6 +83,8 @@ def metrics(
                 usage = metrics_by_container.get(key, {})
                 cpu_raw = usage.get("cpu", "0n") if usage else "0n"
                 mem_raw = usage.get("memory", "0Ki") if usage else "0Ki"
+                cpu_percent = utils.calculate_cpu_percentage(usage.get("cpu"), limits.get("cpu"))
+                mem_percent = utils.calculate_memory_percentage(usage.get("memory"), limits.get("memory"))
 
                 rows.append(
                     {
@@ -92,11 +94,11 @@ def metrics(
                         "cpu_req": requests.get("cpu", "-"),
                         "cpu_limit": limits.get("cpu", "-"),
                         "cpu_usage": utils.parse_cpu(cpu_raw) if usage else "-",
-                        "cpu_percent": utils.calculate_cpu_percentage(usage.get("cpu"), limits.get("cpu")),
+                        "cpu_percent": f"{cpu_percent:.2f}%",
                         "mem_req": requests.get("memory", "-"),
                         "mem_limit": limits.get("memory", "-"),
                         "mem_usage": utils.parse_memory(mem_raw) if usage else "-",
-                        "mem_percent": utils.calculate_memory_percentage(usage.get("memory"), limits.get("memory")),
+                        "mem_percent": f"{mem_percent:.2f}%",
                         "cpu_value": utils.parse_cpu(cpu_raw, return_number=True) if usage else 0,
                         "mem_value": utils.parse_memory(mem_raw, return_number=True) if usage else 0,
                     }
@@ -168,6 +170,123 @@ def unhealthy(namespace: Annotated[str, typer.Option("--namespace", "-n")] = Non
             restart_count = sum((status.restart_count or 0) for status in statuses)
             if pod.status.phase not in ("Running", "Succeeded"):
                 table.add_row(pod.metadata.namespace or "-", pod.metadata.name, str(restart_count), utils.calculate_age(pod.status.start_time), pod.status.phase)
+
+        console.print(table)
+    except Exception as err:
+        console.print(f"[bold red]Error accessing Kubernetes:[/bold red] \n\n{err}")
+
+
+@app.command()
+def overprovisioned(
+    namespace: Annotated[str, typer.Option("--namespace", "-n")] = None,
+    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False,
+    sort_by: Annotated[ResourcesChoice, typer.Option("--sort-by", "-s")] = None,
+    limit: Annotated[int, typer.Option("--limit", "-l", min=1)] = None,
+    threshold: Annotated[float, typer.Option("--threshold", "-th", min=0)] = 20,
+):
+    """Retrieve CPU and memory resources (requests, limits, usage) for all pods."""
+    utils.load_kube_config()
+    namespace = namespace or utils.get_current_namespace()
+    scope = "all namespaces" if all_namespaces else f"namespace {namespace}"
+    console.print(f"[bold blue]Listing pod resources in {scope}...[/bold blue]")
+
+    metrics_by_container = {}
+    try:
+        metrics_by_container = utils.fetch_pod_metrics(namespace, all_namespaces)
+    except Exception as e:
+        console.print("[yellow]Warning: Could not fetch metrics (Metrics Server may not be installed)[/yellow]")
+        console.print(f"[dim]Details: {e}[/dim]")
+
+    try:
+        v1 = client.CoreV1Api()
+        pods = v1.list_pod_for_all_namespaces(watch=False) if all_namespaces else v1.list_namespaced_pod(namespace, watch=False)
+
+        rows = []
+        for pod in pods.items:
+            pod_ns = pod.metadata.namespace or "-"
+            pod_name = pod.metadata.name
+            for container in pod.spec.containers:
+                resources = container.resources
+                limits = getattr(resources, "limits", None) or {}
+                requests = getattr(resources, "requests", None) or {}
+                key = (pod_ns, pod_name, container.name)
+                usage = metrics_by_container.get(key, {})
+                cpu_raw = usage.get("cpu", "0n") if usage else "0n"
+                mem_raw = usage.get("memory", "0Ki") if usage else "0Ki"
+
+                cpu_req = requests.get("cpu", "-")
+                cpu_limit = limits.get("cpu", "-")
+                cpu_usage = utils.parse_cpu(cpu_raw) if usage else "-"
+                cpu_percent = f"{utils.calculate_cpu_percentage(usage.get('cpu'), limits.get('cpu')):.2f}%"
+                mem_req = requests.get("memory", "-")
+                mem_limit = limits.get("memory", "-")
+                mem_usage = utils.parse_memory(mem_raw) if usage else "-"
+                mem_percent = f"{utils.calculate_memory_percentage(usage.get('memory'), limits.get('memory')):.2f}%"
+                cpu_value = utils.parse_cpu(cpu_raw, return_number=True) if usage else 0
+                mem_value = utils.parse_memory(mem_raw, return_number=True) if usage else 0
+
+                cpu_provisioned = utils.calculate_cpu_percentage(usage.get("cpu"), requests.get("cpu"))
+                memory_provisioned = utils.calculate_memory_percentage(usage.get("memory"), requests.get("memory"))
+
+                if cpu_provisioned < threshold or memory_provisioned < threshold:
+                    rows.append(
+                        {
+                            "namespace": pod_ns,
+                            "pod": pod_name,
+                            "container": container.name,
+                            "cpu_req": cpu_req,
+                            "cpu_limit": cpu_limit,
+                            "cpu_usage": cpu_usage,
+                            "cpu_percent": cpu_percent,
+                            "cpu_provisioned": f"{cpu_provisioned:.2f}%",
+                            "mem_req": mem_req,
+                            "mem_limit": mem_limit,
+                            "mem_usage": mem_usage,
+                            "mem_percent": mem_percent,
+                            "memory_provisioned": f"{memory_provisioned:.2f}%",
+                            "cpu_value": cpu_value,
+                            "mem_value": mem_value,
+                        }
+                    )
+
+        if sort_by:
+            sort_key = "cpu_value" if sort_by == ResourcesChoice.cpu else "mem_value"
+            rows.sort(key=lambda x: x[sort_key], reverse=True)
+
+        if limit:
+            rows = rows[:limit]
+
+        table = Table(title=f"Pod Resources in {scope}")
+        table.add_column("Namespace", style="cyan", justify="center")
+        table.add_column("Pod Name", style="cyan", justify="center")
+        table.add_column("Container", style="cyan", justify="center")
+        table.add_column("CPU Req", style="green", justify="center")
+        table.add_column("CPU Limit", style="yellow", justify="center")
+        table.add_column("CPU Usage", style="magenta", justify="center")
+        table.add_column("CPU Usage %", style="magenta", justify="center")
+        table.add_column("CPU From Request %", style="magenta", justify="center")
+        table.add_column("Mem Req", style="green", justify="center")
+        table.add_column("Mem Limit", style="yellow", justify="center")
+        table.add_column("Mem Usage", style="magenta", justify="center")
+        table.add_column("Mem Usage %", style="magenta", justify="center")
+        table.add_column("Mem From Request %", style="magenta", justify="center")
+
+        for row in rows:
+            table.add_row(
+                row["namespace"],
+                row["pod"],
+                row["container"],
+                row["cpu_req"],
+                row["cpu_limit"],
+                row["cpu_usage"],
+                row["cpu_percent"],
+                row["cpu_provisioned"],
+                row["mem_req"],
+                row["mem_limit"],
+                row["mem_usage"],
+                row["mem_percent"],
+                row["memory_provisioned"],
+            )
 
         console.print(table)
     except Exception as err:

--- a/src/devopstoolbox/k8s/services.py
+++ b/src/devopstoolbox/k8s/services.py
@@ -12,8 +12,11 @@ console = Console()
 
 
 @app.command()
-def list(namespace: Annotated[str, typer.Option("--namespace", "-n")] = None, all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A")] = False):
-    """List services"""
+def list(
+    namespace: Annotated[str, typer.Option("--namespace", "-n", help="Kubernetes namespace to query")] = None,
+    all_namespaces: Annotated[bool, typer.Option("--all-namespaces", "-A", help="Query all namespaces")] = False,
+):
+    """List all services with type and traffic policy."""
     utils.load_kube_config()
     namespace = namespace or utils.get_current_namespace()
     scope = "all namespaces" if all_namespaces else f"namespace {namespace}"

--- a/src/devopstoolbox/k8s/utils.py
+++ b/src/devopstoolbox/k8s/utils.py
@@ -82,22 +82,22 @@ def parse_memory(mem_str: str, return_number: bool = False):
         return f"{bytes_val} B"
 
 
-def calculate_cpu_percentage(usage, limit):
+def calculate_cpu_percentage(usage, limit) -> float:
     """Calculate CPU usage percentage from usage and limit values."""
     if usage is None or limit is None or not (usage[:-1].isdigit() or usage.isdigit()) or not (limit[:-1].isdigit() or limit.isdigit()):
-        return "-"
+        return 0
     else:
         result = parse_cpu(usage, return_number=True) / parse_cpu(limit, return_number=True) * 100
-        return f"{result:.2f}%"
+        return result
 
 
-def calculate_memory_percentage(usage, limit):
+def calculate_memory_percentage(usage, limit) -> float:
     """Calculate Memory usage percentage from usage and limit values."""
     if usage is None or limit is None or not usage[:-2].isdigit() or not limit[:-2].isdigit():
-        return "-"
+        return 0
     else:
         result = parse_memory(usage, return_number=True) / parse_memory(limit, return_number=True) * 100
-        return f"{result:.2f}%"
+        return result
 
 
 def calculate_age(start_time):

--- a/src/devopstoolbox/k8s/utils.py
+++ b/src/devopstoolbox/k8s/utils.py
@@ -66,7 +66,7 @@ def parse_memory(mem_str: str, return_number: bool = False):
     units = {"Ki": 1024, "Mi": 1024**2, "Gi": 1024**3, "Ti": 1024**4}
     match = re.match(r"^(\d+)(Ki|Mi|Gi|Ti)?$", mem_str)
     if not match:
-        return mem_str
+        return 0 if return_number else mem_str
     value = int(match.group(1))
     unit = match.group(2) or ""
     bytes_val = value * units.get(unit, 1)
@@ -86,18 +86,22 @@ def calculate_cpu_percentage(usage, limit) -> float:
     """Calculate CPU usage percentage from usage and limit values."""
     if usage is None or limit is None or not (usage[:-1].isdigit() or usage.isdigit()) or not (limit[:-1].isdigit() or limit.isdigit()):
         return 0
-    else:
-        result = parse_cpu(usage, return_number=True) / parse_cpu(limit, return_number=True) * 100
-        return result
+    limit_value = parse_cpu(limit, return_number=True)
+    if limit_value == 0:
+        return 0
+    result = parse_cpu(usage, return_number=True) / limit_value * 100
+    return result
 
 
 def calculate_memory_percentage(usage, limit) -> float:
     """Calculate Memory usage percentage from usage and limit values."""
     if usage is None or limit is None or not usage[:-2].isdigit() or not limit[:-2].isdigit():
         return 0
-    else:
-        result = parse_memory(usage, return_number=True) / parse_memory(limit, return_number=True) * 100
-        return result
+    limit_value = parse_memory(limit, return_number=True)
+    if limit_value == 0:
+        return 0
+    result = parse_memory(usage, return_number=True) / limit_value * 100
+    return result
 
 
 def calculate_age(start_time):

--- a/src/devopstoolbox/misc/validate.py
+++ b/src/devopstoolbox/misc/validate.py
@@ -44,8 +44,8 @@ def validate_json_file(file_path: Path) -> tuple[bool, str]:
 
 @app.command()
 def yaml(
-    file: Annotated[Path, typer.Option("--file", "-f", exists=True, file_okay=True, dir_okay=False, resolve_path=True)] = None,
-    directory: Annotated[Path, typer.Option("--directory", "-d", exists=True, file_okay=False, dir_okay=True, resolve_path=True)] = None,
+    file: Annotated[Path, typer.Option("--file", "-f", exists=True, file_okay=True, dir_okay=False, resolve_path=True, help="Single YAML file to validate")] = None,
+    directory: Annotated[Path, typer.Option("--directory", "-d", exists=True, file_okay=False, dir_okay=True, resolve_path=True, help="Directory to scan for YAML files")] = None,
 ):
     """Validate YAML files for syntax errors."""
     if file is None and directory is None:
@@ -93,8 +93,8 @@ def yaml(
 
 @app.command()
 def json(
-    file: Annotated[Path, typer.Option("--file", "-f", exists=True, file_okay=True, dir_okay=False, resolve_path=True)] = None,
-    directory: Annotated[Path, typer.Option("--directory", "-d", exists=True, file_okay=False, dir_okay=True, resolve_path=True)] = None,
+    file: Annotated[Path, typer.Option("--file", "-f", exists=True, file_okay=True, dir_okay=False, resolve_path=True, help="Single JSON file to validate")] = None,
+    directory: Annotated[Path, typer.Option("--directory", "-d", exists=True, file_okay=False, dir_okay=True, resolve_path=True, help="Directory to scan for JSON files")] = None,
 ):
     """Validate JSON files for syntax errors."""
     if file is None and directory is None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -66,3 +66,42 @@ class TestAppStructure:
         assert result.exit_code == 0
         assert "list" in result.output
         assert "not-ready" in result.output
+
+    def test_misc_subcommand_exists(self):
+        """Test that misc subcommand is available."""
+        result = runner.invoke(app, ["misc", "--help"])
+
+        assert result.exit_code == 0
+        assert "generate" in result.output
+        assert "validate" in result.output
+        assert "base64" in result.output
+
+    def test_k8s_jobs_subcommand_exists(self):
+        """Test that k8s jobs subcommand is available."""
+        result = runner.invoke(app, ["k8s", "jobs", "--help"])
+
+        assert result.exit_code == 0
+        assert "list" in result.output
+
+
+class TestMainModule:
+    """Tests for main module entry point."""
+
+    def test_main_module_execution(self):
+        """Test that the main module can be run as script."""
+        import runpy
+        import sys
+
+        import pytest
+
+        original_argv = sys.argv
+        try:
+            sys.argv = ["devopstoolbox", "--help"]
+            # Run the module as __main__ - this will trigger the if __name__ == "__main__" block
+            # SystemExit is expected because typer exits after showing help
+            with pytest.raises(SystemExit) as exc_info:
+                runpy.run_module("devopstoolbox.main", run_name="__main__", alter_sys=True)
+            # Exit code 0 means success (help was displayed)
+            assert exc_info.value.code == 0
+        finally:
+            sys.argv = original_argv

--- a/tests/test_pods.py
+++ b/tests/test_pods.py
@@ -447,3 +447,255 @@ class TestPodsMetricsCommand:
         output_lines = result.output.split("\n")
         data_rows = [line for line in output_lines if "100m" in line and "500m" not in line]
         assert len(data_rows) == 0, "Pod with 100m CPU should be excluded by limit"
+
+
+class TestPodsOverprovisionedCommand:
+    """Tests for pods overprovisioned command."""
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_overprovisioned_default_namespace(self, mock_fetch_metrics, mock_core_api):
+        """Test overprovisioned command with default namespace."""
+        mock_fetch_metrics.return_value = {}
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+        mock_v1.list_namespaced_pod.return_value = Mock(items=[])
+
+        result = runner.invoke(pods.app, ["overprovisioned"])
+
+        assert result.exit_code == 0
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_overprovisioned_specific_namespace(self, mock_fetch_metrics, mock_core_api):
+        """Test overprovisioned command with specific namespace."""
+        mock_fetch_metrics.return_value = {}
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+        mock_v1.list_namespaced_pod.return_value = Mock(items=[])
+
+        result = runner.invoke(pods.app, ["overprovisioned", "-n", "kube-system"])
+
+        assert result.exit_code == 0
+        mock_v1.list_namespaced_pod.assert_called_once_with("kube-system", watch=False)
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_overprovisioned_all_namespaces(self, mock_fetch_metrics, mock_core_api):
+        """Test overprovisioned command across all namespaces."""
+        mock_fetch_metrics.return_value = {}
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+        mock_v1.list_pod_for_all_namespaces.return_value = Mock(items=[])
+
+        result = runner.invoke(pods.app, ["overprovisioned", "-A"])
+
+        assert result.exit_code == 0
+        mock_v1.list_pod_for_all_namespaces.assert_called_once_with(watch=False)
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_overprovisioned_filters_by_threshold(self, mock_fetch_metrics, mock_core_api):
+        """Test that pods below threshold are shown."""
+        # Pod using 10% of requested CPU (10m of 100m)
+        mock_fetch_metrics.return_value = {("default", "lpod", "main"): {"cpu": "10m", "memory": "10Mi"}}
+
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+
+        container = Mock()
+        container.name = "main"
+        container.resources.requests = {"cpu": "100m", "memory": "100Mi"}
+        container.resources.limits = {"cpu": "200m", "memory": "200Mi"}
+
+        pod = Mock()
+        pod.metadata.namespace = "default"
+        pod.metadata.name = "lpod"
+        pod.spec.containers = [container]
+
+        mock_pods = Mock()
+        mock_pods.items = [pod]
+        mock_v1.list_namespaced_pod.return_value = mock_pods
+
+        result = runner.invoke(pods.app, ["overprovisioned", "-n", "default", "--threshold", "50"])
+
+        assert result.exit_code == 0
+        # Pod name is truncated in Rich table output, check for partial match
+        assert "lp" in result.output
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_overprovisioned_excludes_well_utilized_pods(self, mock_fetch_metrics, mock_core_api):
+        """Test that pods above threshold are not shown."""
+        # Pod using 80% of requested CPU (80m of 100m)
+        mock_fetch_metrics.return_value = {("default", "well-utilized-pod", "main"): {"cpu": "80m", "memory": "80Mi"}}
+
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+
+        container = Mock()
+        container.name = "main"
+        container.resources.requests = {"cpu": "100m", "memory": "100Mi"}
+        container.resources.limits = {"cpu": "200m", "memory": "200Mi"}
+
+        pod = Mock()
+        pod.metadata.namespace = "default"
+        pod.metadata.name = "well-utilized-pod"
+        pod.spec.containers = [container]
+
+        mock_pods = Mock()
+        mock_pods.items = [pod]
+        mock_v1.list_namespaced_pod.return_value = mock_pods
+
+        result = runner.invoke(pods.app, ["overprovisioned", "-n", "default", "--threshold", "50"])
+
+        assert result.exit_code == 0
+        assert "well-utilized-pod" not in result.output
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_overprovisioned_custom_threshold(self, mock_fetch_metrics, mock_core_api):
+        """Test overprovisioned command with custom threshold."""
+        # Pod using 25% of requested resources
+        mock_fetch_metrics.return_value = {("default", "xyz", "main"): {"cpu": "25m", "memory": "25Mi"}}
+
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+
+        container = Mock()
+        container.name = "main"
+        container.resources.requests = {"cpu": "100m", "memory": "100Mi"}
+        container.resources.limits = {"cpu": "200m", "memory": "200Mi"}
+
+        pod = Mock()
+        pod.metadata.namespace = "default"
+        pod.metadata.name = "xyz"
+        pod.spec.containers = [container]
+
+        mock_pods = Mock()
+        mock_pods.items = [pod]
+        mock_v1.list_namespaced_pod.return_value = mock_pods
+
+        # With 30% threshold, pod should be shown (25% < 30%)
+        result = runner.invoke(pods.app, ["overprovisioned", "-n", "default", "--threshold", "30"])
+        assert result.exit_code == 0
+        assert "xyz" in result.output
+
+        # With 20% threshold, pod should NOT be shown (25% > 20%)
+        result = runner.invoke(pods.app, ["overprovisioned", "-n", "default", "--threshold", "20"])
+        assert result.exit_code == 0
+        assert "xyz" not in result.output
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_overprovisioned_handles_metrics_error(self, mock_fetch_metrics, mock_core_api):
+        """Test handling metrics API errors."""
+        mock_fetch_metrics.side_effect = Exception("Metrics Server not available")
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+        mock_v1.list_namespaced_pod.return_value = Mock(items=[])
+
+        result = runner.invoke(pods.app, ["overprovisioned"])
+
+        assert result.exit_code == 0
+        assert "Metrics Server" in result.output
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_overprovisioned_sort_by_cpu(self, mock_fetch_metrics, mock_core_api):
+        """Test sorting overprovisioned pods by CPU."""
+        mock_fetch_metrics.return_value = {
+            ("default", "aaa", "main"): {"cpu": "10m", "memory": "10Mi"},
+            ("default", "zzz", "main"): {"cpu": "40m", "memory": "10Mi"},
+        }
+
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+
+        pods_list = []
+        for name in ["aaa", "zzz"]:
+            container = Mock()
+            container.name = "main"
+            container.resources.requests = {"cpu": "100m", "memory": "100Mi"}
+            container.resources.limits = {"cpu": "200m", "memory": "200Mi"}
+
+            pod = Mock()
+            pod.metadata.namespace = "default"
+            pod.metadata.name = name
+            pod.spec.containers = [container]
+            pods_list.append(pod)
+
+        mock_pods = Mock()
+        mock_pods.items = pods_list
+        mock_v1.list_namespaced_pod.return_value = mock_pods
+
+        result = runner.invoke(pods.app, ["overprovisioned", "-n", "default", "-s", "cpu"])
+
+        assert result.exit_code == 0
+        # When sorted by CPU descending, zzz (40m) should appear before aaa (10m)
+        zzz_pos = result.output.find("zzz")
+        aaa_pos = result.output.find("aaa")
+        assert zzz_pos < aaa_pos, "Higher CPU usage should appear first"
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_overprovisioned_limit_results(self, mock_fetch_metrics, mock_core_api):
+        """Test limiting the number of overprovisioned results."""
+        mock_fetch_metrics.return_value = {
+            ("default", "aaa", "main"): {"cpu": "10m", "memory": "10Mi"},
+            ("default", "bbb", "main"): {"cpu": "20m", "memory": "10Mi"},
+            ("default", "ccc", "main"): {"cpu": "30m", "memory": "10Mi"},
+        }
+
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+
+        pods_list = []
+        for name in ["aaa", "bbb", "ccc"]:
+            container = Mock()
+            container.name = "main"
+            container.resources.requests = {"cpu": "100m", "memory": "100Mi"}
+            container.resources.limits = {"cpu": "200m", "memory": "200Mi"}
+
+            pod = Mock()
+            pod.metadata.namespace = "default"
+            pod.metadata.name = name
+            pod.spec.containers = [container]
+            pods_list.append(pod)
+
+        mock_pods = Mock()
+        mock_pods.items = pods_list
+        mock_v1.list_namespaced_pod.return_value = mock_pods
+
+        result = runner.invoke(pods.app, ["overprovisioned", "-n", "default", "-s", "cpu", "-l", "2"])
+
+        assert result.exit_code == 0
+        # After sorting by CPU descending and limiting to 2, ccc (30m) and bbb (20m) should be shown
+        assert "ccc" in result.output
+        assert "bbb" in result.output
+        assert "aaa" not in result.output
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_overprovisioned_shows_request_percentage(self, mock_fetch_metrics, mock_core_api, mock_container):
+        """Test that output shows CPU and memory percentage of request columns."""
+        mock_fetch_metrics.return_value = {("default", "abc", "main"): {"cpu": "10m", "memory": "10Mi"}}
+
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+
+        pod = Mock()
+        pod.metadata.namespace = "default"
+        pod.metadata.name = "abc"
+        mock_container.name = "main"
+        pod.spec.containers = [mock_container]
+
+        mock_pods = Mock()
+        mock_pods.items = [pod]
+        mock_v1.list_namespaced_pod.return_value = mock_pods
+
+        result = runner.invoke(pods.app, ["overprovisioned", "-n", "default"])
+
+        assert result.exit_code == 0
+        # Check for "Request" in output (may be truncated in Rich table)
+        assert "Request" in result.output or "Req" in result.output

--- a/tests/test_pods.py
+++ b/tests/test_pods.py
@@ -1,5 +1,6 @@
 """Tests for devopstoolbox.k8s.pods module."""
 
+from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
 import pytest
@@ -308,6 +309,9 @@ class TestPodsMetricsCommand:
         pod = Mock()
         pod.metadata.namespace = "default"
         pod.metadata.name = "test-pod"
+        pod.status.phase = "Running"
+        pod.status.container_statuses = []
+        pod.status.start_time = datetime.now(timezone.utc)
         mock_container.name = "main"
         pod.spec.containers = [mock_container]
 
@@ -348,11 +352,15 @@ class TestPodsMetricsCommand:
         low_cpu_pod = Mock()
         low_cpu_pod.metadata.namespace = "default"
         low_cpu_pod.metadata.name = "aaa"
+        low_cpu_pod.status.container_statuses = []
+        low_cpu_pod.status.start_time = datetime.now(timezone.utc)
         low_cpu_pod.spec.containers = [low_cpu_container]
 
         high_cpu_pod = Mock()
         high_cpu_pod.metadata.namespace = "default"
         high_cpu_pod.metadata.name = "zzz"
+        high_cpu_pod.status.container_statuses = []
+        high_cpu_pod.status.start_time = datetime.now(timezone.utc)
         high_cpu_pod.spec.containers = [high_cpu_container]
 
         mock_pods = Mock()
@@ -391,11 +399,15 @@ class TestPodsMetricsCommand:
         low_mem_pod = Mock()
         low_mem_pod.metadata.namespace = "default"
         low_mem_pod.metadata.name = "aaa"
+        low_mem_pod.status.container_statuses = []
+        low_mem_pod.status.start_time = datetime.now(timezone.utc)
         low_mem_pod.spec.containers = [low_mem_container]
 
         high_mem_pod = Mock()
         high_mem_pod.metadata.namespace = "default"
         high_mem_pod.metadata.name = "zzz"
+        high_mem_pod.status.container_statuses = []
+        high_mem_pod.status.start_time = datetime.now(timezone.utc)
         high_mem_pod.spec.containers = [high_mem_container]
 
         mock_pods = Mock()
@@ -432,6 +444,8 @@ class TestPodsMetricsCommand:
             pod = Mock()
             pod.metadata.namespace = "default"
             pod.metadata.name = name
+            pod.status.container_statuses = []
+            pod.status.start_time = datetime.now(timezone.utc)
             pod.spec.containers = [container]
             pods_list.append(pod)
 
@@ -511,6 +525,8 @@ class TestPodsOverprovisionedCommand:
         pod = Mock()
         pod.metadata.namespace = "default"
         pod.metadata.name = "lpod"
+        pod.status.container_statuses = []
+        pod.status.start_time = datetime.now(timezone.utc)
         pod.spec.containers = [container]
 
         mock_pods = Mock()
@@ -541,6 +557,8 @@ class TestPodsOverprovisionedCommand:
         pod = Mock()
         pod.metadata.namespace = "default"
         pod.metadata.name = "well-utilized-pod"
+        pod.status.container_statuses = []
+        pod.status.start_time = datetime.now(timezone.utc)
         pod.spec.containers = [container]
 
         mock_pods = Mock()
@@ -570,6 +588,8 @@ class TestPodsOverprovisionedCommand:
         pod = Mock()
         pod.metadata.namespace = "default"
         pod.metadata.name = "xyz"
+        pod.status.container_statuses = []
+        pod.status.start_time = datetime.now(timezone.utc)
         pod.spec.containers = [container]
 
         mock_pods = Mock()
@@ -622,6 +642,8 @@ class TestPodsOverprovisionedCommand:
             pod = Mock()
             pod.metadata.namespace = "default"
             pod.metadata.name = name
+            pod.status.container_statuses = []
+            pod.status.start_time = datetime.now(timezone.utc)
             pod.spec.containers = [container]
             pods_list.append(pod)
 
@@ -660,6 +682,8 @@ class TestPodsOverprovisionedCommand:
             pod = Mock()
             pod.metadata.namespace = "default"
             pod.metadata.name = name
+            pod.status.container_statuses = []
+            pod.status.start_time = datetime.now(timezone.utc)
             pod.spec.containers = [container]
             pods_list.append(pod)
 
@@ -687,6 +711,8 @@ class TestPodsOverprovisionedCommand:
         pod = Mock()
         pod.metadata.namespace = "default"
         pod.metadata.name = "abc"
+        pod.status.container_statuses = []
+        pod.status.start_time = datetime.now(timezone.utc)
         mock_container.name = "main"
         pod.spec.containers = [mock_container]
 

--- a/tests/test_pods.py
+++ b/tests/test_pods.py
@@ -73,28 +73,59 @@ class TestPodsListCommand:
     """Tests for pods list command."""
 
     @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
-    def test_list_pods_default_namespace(self, mock_api, mock_pod):
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_list_pods_default_namespace(self, mock_fetch_metrics, mock_api):
         """Test listing pods in default namespace."""
+        mock_fetch_metrics.return_value = {}
         mock_v1 = Mock()
         mock_api.return_value = mock_v1
 
+        container = Mock()
+        container.name = "main"
+        container.resources.requests = {"cpu": "100m", "memory": "128Mi"}
+        container.resources.limits = {"cpu": "200m", "memory": "256Mi"}
+
+        pod = Mock()
+        pod.metadata.namespace = "default"
+        pod.metadata.name = "test-pod"
+        pod.status.phase = "Running"
+        pod.status.container_statuses = []
+        pod.status.start_time = datetime.now(timezone.utc)
+        pod.spec.containers = [container]
+
         mock_pods = Mock()
-        mock_pods.items = [mock_pod]
+        mock_pods.items = [pod]
         mock_v1.list_namespaced_pod.return_value = mock_pods
 
         result = runner.invoke(pods.app, ["list", "-n", "default"])
 
         assert result.exit_code == 0
+        assert "test-pod" in result.output
         mock_v1.list_namespaced_pod.assert_called_once_with("default", watch=False)
 
     @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
-    def test_list_pods_specific_namespace_long(self, mock_api, mock_pod):
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_list_pods_specific_namespace_long(self, mock_fetch_metrics, mock_api):
         """Test listing pods in a specific namespace."""
+        mock_fetch_metrics.return_value = {}
         mock_v1 = Mock()
         mock_api.return_value = mock_v1
 
+        container = Mock()
+        container.name = "main"
+        container.resources.requests = {"cpu": "100m", "memory": "128Mi"}
+        container.resources.limits = {"cpu": "200m", "memory": "256Mi"}
+
+        pod = Mock()
+        pod.metadata.namespace = "kube-system"
+        pod.metadata.name = "test-pod"
+        pod.status.phase = "Running"
+        pod.status.container_statuses = []
+        pod.status.start_time = datetime.now(timezone.utc)
+        pod.spec.containers = [container]
+
         mock_pods = Mock()
-        mock_pods.items = [mock_pod]
+        mock_pods.items = [pod]
         mock_v1.list_namespaced_pod.return_value = mock_pods
 
         result = runner.invoke(pods.app, ["list", "--namespace", "kube-system"])
@@ -103,13 +134,28 @@ class TestPodsListCommand:
         mock_v1.list_namespaced_pod.assert_called_once_with("kube-system", watch=False)
 
     @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
-    def test_list_pods_specific_namespace_short(self, mock_api, mock_pod):
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_list_pods_specific_namespace_short(self, mock_fetch_metrics, mock_api):
         """Test listing pods in a specific namespace."""
+        mock_fetch_metrics.return_value = {}
         mock_v1 = Mock()
         mock_api.return_value = mock_v1
 
+        container = Mock()
+        container.name = "main"
+        container.resources.requests = {"cpu": "100m", "memory": "128Mi"}
+        container.resources.limits = {"cpu": "200m", "memory": "256Mi"}
+
+        pod = Mock()
+        pod.metadata.namespace = "kube-system"
+        pod.metadata.name = "test-pod"
+        pod.status.phase = "Running"
+        pod.status.container_statuses = []
+        pod.status.start_time = datetime.now(timezone.utc)
+        pod.spec.containers = [container]
+
         mock_pods = Mock()
-        mock_pods.items = [mock_pod]
+        mock_pods.items = [pod]
         mock_v1.list_namespaced_pod.return_value = mock_pods
 
         result = runner.invoke(pods.app, ["list", "-n", "kube-system"])
@@ -118,13 +164,28 @@ class TestPodsListCommand:
         mock_v1.list_namespaced_pod.assert_called_once_with("kube-system", watch=False)
 
     @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
-    def test_list_pods_all_namespaces_long(self, mock_api, mock_pod):
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_list_pods_all_namespaces_long(self, mock_fetch_metrics, mock_api):
         """Test listing pods across all namespaces."""
+        mock_fetch_metrics.return_value = {}
         mock_v1 = Mock()
         mock_api.return_value = mock_v1
 
+        container = Mock()
+        container.name = "main"
+        container.resources.requests = {"cpu": "100m", "memory": "128Mi"}
+        container.resources.limits = {"cpu": "200m", "memory": "256Mi"}
+
+        pod = Mock()
+        pod.metadata.namespace = "default"
+        pod.metadata.name = "test-pod"
+        pod.status.phase = "Running"
+        pod.status.container_statuses = []
+        pod.status.start_time = datetime.now(timezone.utc)
+        pod.spec.containers = [container]
+
         mock_pods = Mock()
-        mock_pods.items = [mock_pod]
+        mock_pods.items = [pod]
         mock_v1.list_pod_for_all_namespaces.return_value = mock_pods
 
         result = runner.invoke(pods.app, ["list", "--all-namespaces"])
@@ -133,13 +194,28 @@ class TestPodsListCommand:
         mock_v1.list_pod_for_all_namespaces.assert_called_once_with(watch=False)
 
     @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
-    def test_list_pods_all_namespaces_short(self, mock_api, mock_pod):
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_list_pods_all_namespaces_short(self, mock_fetch_metrics, mock_api):
         """Test listing pods across all namespaces."""
+        mock_fetch_metrics.return_value = {}
         mock_v1 = Mock()
         mock_api.return_value = mock_v1
 
+        container = Mock()
+        container.name = "main"
+        container.resources.requests = {"cpu": "100m", "memory": "128Mi"}
+        container.resources.limits = {"cpu": "200m", "memory": "256Mi"}
+
+        pod = Mock()
+        pod.metadata.namespace = "default"
+        pod.metadata.name = "test-pod"
+        pod.status.phase = "Running"
+        pod.status.container_statuses = []
+        pod.status.start_time = datetime.now(timezone.utc)
+        pod.spec.containers = [container]
+
         mock_pods = Mock()
-        mock_pods.items = [mock_pod]
+        mock_pods.items = [pod]
         mock_v1.list_pod_for_all_namespaces.return_value = mock_pods
 
         result = runner.invoke(pods.app, ["list", "-A"])
@@ -148,16 +224,25 @@ class TestPodsListCommand:
         mock_v1.list_pod_for_all_namespaces.assert_called_once_with(watch=False)
 
     @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
-    def test_list_pods_handles_no_container_statuses(self, mock_api):
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_list_pods_handles_no_container_statuses(self, mock_fetch_metrics, mock_api):
         """Test handling pods with no container statuses."""
+        mock_fetch_metrics.return_value = {}
         mock_v1 = Mock()
         mock_api.return_value = mock_v1
+
+        container = Mock()
+        container.name = "main"
+        container.resources.requests = {"cpu": "100m", "memory": "128Mi"}
+        container.resources.limits = {"cpu": "200m", "memory": "256Mi"}
 
         pod = Mock()
         pod.metadata.namespace = "default"
         pod.metadata.name = "pending-pod"
         pod.status.phase = "Pending"
         pod.status.container_statuses = None
+        pod.status.start_time = datetime.now(timezone.utc)
+        pod.spec.containers = [container]
 
         mock_pods = Mock()
         mock_pods.items = [pod]
@@ -725,3 +810,17 @@ class TestPodsOverprovisionedCommand:
         assert result.exit_code == 0
         # Check for "Request" in output (may be truncated in Rich table)
         assert "Request" in result.output or "Req" in result.output
+
+    @patch("devopstoolbox.k8s.pods.client.CoreV1Api")
+    @patch("devopstoolbox.k8s.utils.fetch_pod_metrics")
+    def test_overprovisioned_handles_api_error(self, mock_fetch_metrics, mock_core_api):
+        """Test handling Kubernetes API errors in overprovisioned command."""
+        mock_fetch_metrics.return_value = {}
+        mock_v1 = Mock()
+        mock_core_api.return_value = mock_v1
+        mock_v1.list_namespaced_pod.side_effect = Exception("API Error")
+
+        result = runner.invoke(pods.app, ["overprovisioned"])
+
+        assert result.exit_code == 0
+        assert "Error" in result.output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,6 +80,11 @@ class TestParseMemory:
         assert parse_memory("invalid") == "invalid"
         assert parse_memory("100MB") == "100MB"
 
+    def test_parse_invalid_return_number(self):
+        """Test that invalid formats return 0 when return_number=True."""
+        assert parse_memory("invalid", return_number=True) == 0
+        assert parse_memory("100MB", return_number=True) == 0
+
     def test_parse_zero(self):
         """Test parsing zero values."""
         assert parse_memory("0Ki") == "0 B"
@@ -96,6 +101,11 @@ class TestCpuPercentage:
         assert calculate_cpu_percentage("1000", "x") == 0
         assert calculate_cpu_percentage("x", "1000") == 0
         assert calculate_cpu_percentage("x", "x") == 0
+
+    def test_calculate_division_by_zero(self):
+        """Test that division by zero returns 0 instead of raising an error."""
+        assert calculate_cpu_percentage("100m", "0m") == 0
+        assert calculate_cpu_percentage("100m", "0n") == 0
 
     def test_parse_nanocores(self):
         assert calculate_cpu_percentage("10000n", "300000n") == pytest.approx(3.3333333333333335)
@@ -129,6 +139,11 @@ class TestMemoryPercentage:
         assert calculate_memory_percentage("1000", "x") == 0
         assert calculate_memory_percentage("x", "1000") == 0
         assert calculate_memory_percentage("x", "x") == 0
+
+    def test_calculate_division_by_zero(self):
+        """Test that division by zero returns 0 instead of raising an error."""
+        assert calculate_memory_percentage("100Mi", "0Ki") == 0
+        assert calculate_memory_percentage("100Mi", "invalid") == 0
 
     def test_alculate_kibibytes(self):
         assert calculate_memory_percentage("1024Ki", "1024Ki") == pytest.approx(100.00)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,72 +88,72 @@ class TestParseMemory:
 
 class TestCpuPercentage:
     def test_calculate_zero(self):
-        assert calculate_cpu_percentage(None, None) == "-"
-        assert calculate_cpu_percentage(None, 1000) == "-"
-        assert calculate_cpu_percentage(100, None) == "-"
+        assert calculate_cpu_percentage(None, None) == 0
+        assert calculate_cpu_percentage(None, 1000) == 0
+        assert calculate_cpu_percentage(100, None) == 0
 
     def test_calculate_invalid(self):
-        assert calculate_cpu_percentage("1000", "x") == "-"
-        assert calculate_cpu_percentage("x", "1000") == "-"
-        assert calculate_cpu_percentage("x", "x") == "-"
+        assert calculate_cpu_percentage("1000", "x") == 0
+        assert calculate_cpu_percentage("x", "1000") == 0
+        assert calculate_cpu_percentage("x", "x") == 0
 
     def test_parse_nanocores(self):
-        assert calculate_cpu_percentage("10000n", "300000n") == "3.33%"
-        assert calculate_cpu_percentage("300000n", "300000n") == "100.00%"
+        assert calculate_cpu_percentage("10000n", "300000n") == pytest.approx(3.3333333333333335)
+        assert calculate_cpu_percentage("300000n", "300000n") == pytest.approx(100.00)
 
     def test_parse_microcores(self):
-        assert calculate_cpu_percentage("100u", "1000u") == "10.00%"
-        assert calculate_cpu_percentage("1000u", "1000u") == "100.00%"
-        assert calculate_cpu_percentage("500u", "1000u") == "50.00%"
+        assert calculate_cpu_percentage("100u", "1000u") == pytest.approx(10.00)
+        assert calculate_cpu_percentage("1000u", "1000u") == pytest.approx(100.00)
+        assert calculate_cpu_percentage("500u", "1000u") == pytest.approx(50.00)
 
     def test_parse_milicores(self):
-        assert calculate_cpu_percentage("10000m", "300000m") == "3.33%"
-        assert calculate_cpu_percentage("300000m", "300000m") == "100.00%"
+        assert calculate_cpu_percentage("10000m", "300000m") == pytest.approx(3.3333333333333335)
+        assert calculate_cpu_percentage("300000m", "300000m") == pytest.approx(100.00)
 
     def test_parse_cores(self):
-        assert calculate_cpu_percentage("1", "3") == "33.33%"
-        assert calculate_cpu_percentage("3", "3") == "100.00%"
+        assert calculate_cpu_percentage("1", "3") == pytest.approx(33.33333333333333)
+        assert calculate_cpu_percentage("3", "3") == pytest.approx(100.00)
 
     def test_parse_mix_nanocores_milicores(self):
-        assert calculate_cpu_percentage("10000m", "300000000000n") == "3.33%"
-        assert calculate_cpu_percentage("300000000000n", "300000m") == "100.00%"
+        assert calculate_cpu_percentage("10000m", "300000000000n") == pytest.approx(3.3333333333333335)
+        assert calculate_cpu_percentage("300000000000n", "300000m") == pytest.approx(100.00)
 
 
 class TestMemoryPercentage:
     def test_calculate_zero(self):
-        assert calculate_memory_percentage(None, None) == "-"
-        assert calculate_memory_percentage(None, 1000) == "-"
-        assert calculate_memory_percentage(100, None) == "-"
+        assert calculate_memory_percentage(None, None) == 0
+        assert calculate_memory_percentage(None, 1000) == 0
+        assert calculate_memory_percentage(100, None) == 0
 
     def test_calculate_invalid(self):
-        assert calculate_memory_percentage("1000", "x") == "-"
-        assert calculate_memory_percentage("x", "1000") == "-"
-        assert calculate_memory_percentage("x", "x") == "-"
+        assert calculate_memory_percentage("1000", "x") == 0
+        assert calculate_memory_percentage("x", "1000") == 0
+        assert calculate_memory_percentage("x", "x") == 0
 
     def test_alculate_kibibytes(self):
-        assert calculate_memory_percentage("1024Ki", "1024Ki") == "100.00%"
-        assert calculate_memory_percentage("1024Ki", "512Ki") == "200.00%"
-        assert calculate_memory_percentage("512Ki", "1024Ki") == "50.00%"
+        assert calculate_memory_percentage("1024Ki", "1024Ki") == pytest.approx(100.00)
+        assert calculate_memory_percentage("1024Ki", "512Ki") == pytest.approx(200.00)
+        assert calculate_memory_percentage("512Ki", "1024Ki") == pytest.approx(50.00)
 
     def test_calculate_parse_mebibytes(self):
-        assert calculate_memory_percentage("1024Mi", "1024Mi") == "100.00%"
-        assert calculate_memory_percentage("1024Mi", "512Mi") == "200.00%"
-        assert calculate_memory_percentage("512Mi", "1024Mi") == "50.00%"
+        assert calculate_memory_percentage("1024Mi", "1024Mi") == pytest.approx(100.00)
+        assert calculate_memory_percentage("1024Mi", "512Mi") == pytest.approx(200.00)
+        assert calculate_memory_percentage("512Mi", "1024Mi") == pytest.approx(50.00)
 
     def test_calculate_parse_gibibytes(self):
-        assert calculate_memory_percentage("1024Gi", "1024Gi") == "100.00%"
-        assert calculate_memory_percentage("1024Gi", "512Gi") == "200.00%"
-        assert calculate_memory_percentage("512Gi", "1024Gi") == "50.00%"
+        assert calculate_memory_percentage("1024Gi", "1024Gi") == pytest.approx(100.00)
+        assert calculate_memory_percentage("1024Gi", "512Gi") == pytest.approx(200.00)
+        assert calculate_memory_percentage("512Gi", "1024Gi") == pytest.approx(50.00)
 
     def test_calculate_parse_tebibytes(self):
-        assert calculate_memory_percentage("1024Ti", "1024Ti") == "100.00%"
-        assert calculate_memory_percentage("1024Ti", "512Ti") == "200.00%"
-        assert calculate_memory_percentage("512Ti", "1024Ti") == "50.00%"
+        assert calculate_memory_percentage("1024Ti", "1024Ti") == pytest.approx(100.00)
+        assert calculate_memory_percentage("1024Ti", "512Ti") == pytest.approx(200.00)
+        assert calculate_memory_percentage("512Ti", "1024Ti") == pytest.approx(50.00)
 
     def test_calculate_parse_bytes(self):
-        assert calculate_memory_percentage("1024", "1024") == "100.00%"
-        assert calculate_memory_percentage("1024", "512") == "200.00%"
-        assert calculate_memory_percentage("512", "1024") == "50.00%"
+        assert calculate_memory_percentage("1024", "1024") == pytest.approx(100.00)
+        assert calculate_memory_percentage("1024", "512") == pytest.approx(200.00)
+        assert calculate_memory_percentage("512", "1024") == pytest.approx(50.00)
 
 
 class TestLoadKubeConfig:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -129,6 +129,19 @@ class TestValidateYamlFile:
                 assert is_valid is False
                 assert "Generic YAML error" in error
 
+    def test_yaml_error_without_problem_mark_real(self, tmp_path):
+        """Test YAMLError without problem_mark attribute using real yaml module."""
+        import yaml
+
+        yaml_file = tmp_path / "test.yaml"
+        yaml_file.write_text(SIMPLE_YAML)
+        # Create a YAMLError without problem_mark
+        yaml_error = yaml.YAMLError("YAML parsing failed")
+        with patch("yaml.safe_load_all", side_effect=yaml_error):
+            is_valid, error = validate_yaml_file(yaml_file)
+            assert is_valid is False
+            assert "YAML parsing failed" in error
+
 
 class TestValidateYamlCommand:
     def test_validate_single_valid_file(self, valid_yaml_file):
@@ -249,6 +262,22 @@ class TestValidateJsonFile:
             is_valid, error = validate_json_file(json_file)
             assert is_valid is False
             assert "Permission denied" in error
+
+    def test_json_decode_error_without_line_col(self, tmp_path):
+        """Test JSONDecodeError without lineno/colno attributes."""
+        import json
+
+        json_file = tmp_path / "test.json"
+        json_file.write_text(SIMPLE_JSON)
+        # Create a JSONDecodeError without lineno/colno by removing them
+        json_error = json.JSONDecodeError("Invalid JSON", "", 0)
+        # Remove lineno and colno attributes
+        del json_error.lineno
+        del json_error.colno
+        with patch("json.load", side_effect=json_error):
+            is_valid, error = validate_json_file(json_file)
+            assert is_valid is False
+            assert "Invalid JSON" in error
 
 
 class TestValidateJsonCommand:


### PR DESCRIPTION
## Summary
- Add `devopstoolbox k8s pods overprovisioned` command to detect pods where resource usage is below threshold percentage of requests
- Refactor shared code between `metrics` and `overprovisioned` commands into helper functions
- Fix bugs in `parse_memory()` and percentage calculation functions for edge cases
- Add comprehensive help text to all CLI commands and options
- Improve test coverage to 100% for pods.py, main.py, base64.py, and validate.py

## Test plan
- [x] Run `pytest` - all 175 tests pass
- [x] Verify `devopstoolbox k8s pods overprovisioned --help` displays correctly
- [x] Test with `--threshold` flag to filter by custom percentage
- [x] Test with `--sort-by cpu` and `--sort-by memory` options
- [x] Test with `--limit` option to restrict results
- [x] Verify coverage is 100% for affected modules

Closes #11