### PR TITLE
Add PyPI publishing workflow with dynamic versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: pypi
+    environment:
+      name: pypi
+      url: https://pypi.org/p/devopstoolbox
     permissions:
       id-token: write
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,12 +12,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install build tools
         run: pip install build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,23 @@ version = "0.1.0"
 description = "A Python-based CLI toolkit for automating daily DevOps operations."
 requires-python = ">=3.9"
 readme = "README.md"
+license = {text = "MIT"}
 authors = [
   { name = "George Farias", email = "georgesouzafarias@gmail.com" },
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Topic :: System :: Systems Administration",
+    "Topic :: Utilities",
 ]
 
 dependencies = [
@@ -42,3 +57,8 @@ select = [
 
 [project.scripts]
 devopstoolbox = "devopstoolbox.main:app"
+
+[project.urls]
+Homepage = "https://github.com/georgesouzafarias/DevOpsToolbox"
+Repository = "https://github.com/georgesouzafarias/DevOpsToolbox"
+Issues = "https://github.com/georgesouzafarias/DevOpsToolbox/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,16 @@ license = {text = "MIT"}
 authors = [
   { name = "George Farias", email = "georgesouzafarias@gmail.com" },
 ]
+keywords = [
+    "devops",
+    "kubernetes",
+    "k8s",
+    "aws",
+    "cli",
+    "automation",
+    "sre",
+    "infrastructure",
+]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "devopstoolbox"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A Python-based CLI toolkit for automating daily DevOps operations."
 requires-python = ">=3.9"
 readme = "README.md"
@@ -62,3 +62,5 @@ devopstoolbox = "devopstoolbox.main:app"
 Homepage = "https://github.com/georgesouzafarias/DevOpsToolbox"
 Repository = "https://github.com/georgesouzafarias/DevOpsToolbox"
 Issues = "https://github.com/georgesouzafarias/DevOpsToolbox/issues"
+
+[tool.setuptools_scm]

--- a/src/devopstoolbox/main.py
+++ b/src/devopstoolbox/main.py
@@ -1,10 +1,15 @@
+from importlib.metadata import version
+
 import typer
 from rich import print
 
 from devopstoolbox.k8s import certificates, jobs, pods, services
 from devopstoolbox.misc import base64, generate, validate
 
-__version__ = "DevOpsToolbox v0.1.0"
+try:
+    __version__ = f"DevOpsToolbox v{version('devopstoolbox')}"
+except Exception:
+    __version__ = "DevOpsToolbox (development)"
 
 app = typer.Typer(no_args_is_help=True)
 k8s_app = typer.Typer(no_args_is_help=True)


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated PyPI publishing on release
- Configure dynamic versioning using setuptools-scm (version from git tags)
- Add PyPI package metadata (classifiers, URLs, license)
- Update main.py to use dynamic version from package metadata

## Configuration
- **Trusted Publishing**: Uses OIDC (no API tokens needed)
- **Dynamic Version**: Tag `v1.0.0` → version `1.0.0`
- **Trigger**: Publishes automatically when a GitHub Release is created

## Setup Required
1. Configure trusted publisher on PyPI: https://pypi.org/manage/account/publishing/
   - Owner: `georgesouzafarias`
   - Repository: `DevOpsToolbox`
   - Workflow: `publish.yml`
   - Environment: `pypi`

2. Create GitHub environment `pypi` in repo Settings > Environments

## Test plan
- [x] Verify setuptools-scm returns correct version
- [x] Verify package builds successfully
- [x] All existing tests pass